### PR TITLE
ERC721 Extensions

### DIFF
--- a/Thirdweb.Tests/Thirdweb.ERC721Extension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.ERC721Extension.Tests.cs
@@ -42,15 +42,26 @@ namespace Thirdweb.Tests
             _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_TransferFrom(wallet, Constants.ADDRESS_ZERO, null, BigInteger.Zero));
             _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_TransferFrom(wallet, Constants.ADDRESS_ZERO, string.Empty, BigInteger.Zero));
 
-            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_IsApprovedForAll(string.Empty, null));
-            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_IsApprovedForAll(null, string.Empty));
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_SafeTransferFrom(null, null, null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_SafeTransferFrom(wallet, null, null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_SafeTransferFrom(wallet, string.Empty, null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_SafeTransferFrom(wallet, Constants.ADDRESS_ZERO, null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_SafeTransferFrom(wallet, Constants.ADDRESS_ZERO, string.Empty, BigInteger.Zero));
 
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_IsApprovedForAll(null, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_IsApprovedForAll(string.Empty, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_IsApprovedForAll(Constants.ADDRESS_ZERO, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_IsApprovedForAll(Constants.ADDRESS_ZERO, string.Empty));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_SetApprovalForAll(null, null, false));
             _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_SetApprovalForAll(wallet, null, false));
             _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_SetApprovalForAll(wallet, string.Empty, false));
 
             contract = null;
 
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_BalanceOf(Constants.ADDRESS_ZERO));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_OwnerOf(BigInteger.Zero));
 
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_Name());
 
@@ -63,6 +74,12 @@ namespace Thirdweb.Tests
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_IsApprovedForAll(null, null));
 
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_SetApprovalForAll(null, null, false));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_TransferFrom(null, null, null, BigInteger.Zero));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_SafeTransferFrom(null, null, null, BigInteger.Zero));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_Approve(null, null, BigInteger.Zero));
         }
 
         [Fact]

--- a/Thirdweb.Tests/Thirdweb.ERC721Extension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.ERC721Extension.Tests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Numerics;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Thirdweb.Tests
+{
+    public class ERC721ExtensionTests : BaseTests
+    {
+        private readonly string _erc721ContractAddress = "0x345E7B4CCA26725197f1Bed802A05691D8EF7770";
+        private readonly BigInteger _chainId = 421614;
+
+        public ERC721ExtensionTests(ITestOutputHelper output)
+            : base(output) { }
+
+        private async Task<IThirdwebWallet> GetWallet()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var privateKeyWallet = await PrivateKeyWallet.Create(client, _testPrivateKey);
+            var smartAccount = await SmartWallet.Create(client, personalWallet: privateKeyWallet, factoryAddress: "0xbf1C9aA4B1A085f7DA890a44E82B0A1289A40052", gasless: true, chainId: 421614);
+            return smartAccount;
+        }
+
+        [Fact]
+        public async Task NullChecks()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+            var wallet = await GetWallet();
+
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_BalanceOf(null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_BalanceOf(string.Empty));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_Approve(null, null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_Approve(wallet, null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_Approve(wallet, string.Empty, BigInteger.Zero));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_TransferFrom(null, null, null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_TransferFrom(wallet, null, null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_TransferFrom(wallet, string.Empty, null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_TransferFrom(wallet, Constants.ADDRESS_ZERO, null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_TransferFrom(wallet, Constants.ADDRESS_ZERO, string.Empty, BigInteger.Zero));
+
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_IsApprovedForAll(string.Empty, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_IsApprovedForAll(null, string.Empty));
+
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_SetApprovalForAll(wallet, null, false));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_SetApprovalForAll(wallet, string.Empty, false));
+
+            contract = null;
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_BalanceOf(Constants.ADDRESS_ZERO));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_Name());
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_Symbol());
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_TokenURI(BigInteger.Zero));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_GetApproved(BigInteger.Zero));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_IsApprovedForAll(null, null));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_SetApprovalForAll(null, null, false));
+        }
+
+        [Fact]
+        public async Task ERC721_BalanceOf()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+            var wallet = await GetWallet();
+            var ownerAddress = await wallet.GetAddress();
+
+            var balance = await contract.ERC721_BalanceOf(ownerAddress);
+
+            Assert.True(balance >= 0);
+        }
+
+        [Fact]
+        public async Task ERC721_OwnerOf()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+            var tokenId = BigInteger.Parse("1");
+
+            var owner = await contract.ERC721_OwnerOf(tokenId);
+
+            Assert.False(string.IsNullOrEmpty(owner));
+        }
+
+        [Fact]
+        public async Task ERC721_Name()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+
+            var name = await contract.ERC721_Name();
+
+            Assert.False(string.IsNullOrEmpty(name));
+        }
+
+        [Fact]
+        public async Task ERC721_Symbol()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+
+            var symbol = await contract.ERC721_Symbol();
+
+            Assert.False(string.IsNullOrEmpty(symbol));
+        }
+
+        [Fact]
+        public async Task ERC721_TokenURI()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+            var tokenId = BigInteger.Parse("1");
+
+            var uri = await contract.ERC721_TokenURI(tokenId);
+
+            Assert.False(string.IsNullOrEmpty(uri));
+        }
+
+        [Fact]
+        public async Task ERC721_GetApproved()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+            var tokenId = BigInteger.Parse("1");
+
+            var approved = await contract.ERC721_GetApproved(tokenId);
+
+            Assert.False(string.IsNullOrEmpty(approved));
+        }
+
+        [Fact]
+        public async Task ERC721_IsApprovedForAll()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+            var ownerAddress = Constants.ADDRESS_ZERO;
+            var operatorAddress = contract.Address;
+
+            var isApproved = await contract.ERC721_IsApprovedForAll(ownerAddress, operatorAddress);
+
+            Assert.True(isApproved || !isApproved);
+        }
+
+        // [Fact]
+        // public async Task ERC721_Approve()
+        // {
+        //     var client = ThirdwebClient.Create(secretKey: _secretKey);
+        //     var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+        //     var wallet = await GetWallet();
+
+        //     var toAddress = contract.Address;
+        //     var tokenId = BigInteger.Parse("1");
+
+        //     var receipt = await contract.ERC721_Approve(wallet, toAddress, tokenId);
+
+        //     Assert.True(receipt.TransactionHash.Length == 66);
+        // }
+
+        // [Fact]
+        // public async Task ERC721_SetApprovalForAll()
+        // {
+        //     var client = ThirdwebClient.Create(secretKey: _secretKey);
+        //     var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+        //     var wallet = await GetWallet();
+        //     var operatorAddress = contract.Address;
+        //     var approved = true;
+
+        //     var receipt = await contract.ERC721_SetApprovalForAll(wallet, operatorAddress, approved);
+
+        //     Assert.True(receipt.TransactionHash.Length == 66);
+        // }
+
+        // [Fact]
+        // public async Task ERC721_TransferFrom()
+        // {
+        //     var client = ThirdwebClient.Create(secretKey: _secretKey);
+        //     var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+        //     var wallet = await GetWallet();
+        //     var fromAddress = await wallet.GetAddress();
+        //     var toAddress = contract.Address;
+        //     var tokenId = BigInteger.Parse("1");
+
+        //     var receipt = await contract.ERC721_TransferFrom(wallet, fromAddress, toAddress, tokenId);
+
+        //     Assert.True(receipt.TransactionHash.Length == 66);
+        // }
+
+        // [Fact]
+        // public async Task ERC721_SafeTransferFrom()
+        // {
+        //     var client = ThirdwebClient.Create(secretKey: _secretKey);
+        //     var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+        //     var wallet = await GetWallet();
+        //     var fromAddress = await wallet.GetAddress();
+        //     var toAddress = contract.Address;
+        //     var tokenId = BigInteger.Parse("1");
+
+        //     var receipt = await contract.ERC721_SafeTransferFrom(wallet, fromAddress, toAddress, tokenId);
+
+        //     Assert.True(receipt.TransactionHash.Length == 66);
+        // }
+    }
+}

--- a/Thirdweb/Thirdweb.Contracts/ThirdwebContractExtensions.cs
+++ b/Thirdweb/Thirdweb.Contracts/ThirdwebContractExtensions.cs
@@ -5,6 +5,8 @@ namespace Thirdweb
 {
     public static class ThirdwebContractExtensions
     {
+        #region ERC20
+
         // Check the balance of a specific address
         public static async Task<BigInteger> ERC20_BalanceOf(this ThirdwebContract contract, string ownerAddress)
         {
@@ -153,5 +155,197 @@ namespace Thirdweb
 
             return await ThirdwebContract.Write(wallet, contract, "transferFrom", 0, fromAddress, toAddress, amount);
         }
+
+        #endregion
+
+        #region ERC721
+
+        // Check the balance of a specific address
+        public static async Task<BigInteger> ERC721_BalanceOf(this ThirdwebContract contract, string ownerAddress)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (string.IsNullOrEmpty(ownerAddress))
+            {
+                throw new ArgumentException("Owner address must be provided");
+            }
+
+            return await ThirdwebContract.Read<BigInteger>(contract, "balanceOf", ownerAddress);
+        }
+
+        // Get the owner of a specific token
+        public static async Task<string> ERC721_OwnerOf(this ThirdwebContract contract, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            return await ThirdwebContract.Read<string>(contract, "ownerOf", tokenId);
+        }
+
+        // Get the name of the token
+        public static async Task<string> ERC721_Name(this ThirdwebContract contract)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            return await ThirdwebContract.Read<string>(contract, "name");
+        }
+
+        // Get the symbol of the token
+        public static async Task<string> ERC721_Symbol(this ThirdwebContract contract)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            return await ThirdwebContract.Read<string>(contract, "symbol");
+        }
+
+        // Get the URI of a specific token
+        public static async Task<string> ERC721_TokenURI(this ThirdwebContract contract, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            return await ThirdwebContract.Read<string>(contract, "tokenURI", tokenId);
+        }
+
+        // Approve a specific address to transfer a specific token
+        public static async Task<TransactionReceipt> ERC721_Approve(this ThirdwebContract contract, IThirdwebWallet wallet, string toAddress, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (wallet == null)
+            {
+                throw new ArgumentNullException(nameof(wallet));
+            }
+
+            if (string.IsNullOrEmpty(toAddress))
+            {
+                throw new ArgumentException("Recipient address must be provided");
+            }
+
+            return await ThirdwebContract.Write(wallet, contract, "approve", 0, toAddress, tokenId);
+        }
+
+        // Get the approved address for a specific token
+        public static async Task<string> ERC721_GetApproved(this ThirdwebContract contract, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            return await ThirdwebContract.Read<string>(contract, "getApproved", tokenId);
+        }
+
+        // Check if an address is an operator for another address
+        public static async Task<bool> ERC721_IsApprovedForAll(this ThirdwebContract contract, string ownerAddress, string operatorAddress)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (string.IsNullOrEmpty(ownerAddress))
+            {
+                throw new ArgumentException("Owner address must be provided");
+            }
+
+            if (string.IsNullOrEmpty(operatorAddress))
+            {
+                throw new ArgumentException("Operator address must be provided");
+            }
+
+            return await ThirdwebContract.Read<bool>(contract, "isApprovedForAll", ownerAddress, operatorAddress);
+        }
+
+        // Set or unset an operator for an owner
+        public static async Task<TransactionReceipt> ERC721_SetApprovalForAll(this ThirdwebContract contract, IThirdwebWallet wallet, string operatorAddress, bool approved)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (wallet == null)
+            {
+                throw new ArgumentNullException(nameof(wallet));
+            }
+
+            if (string.IsNullOrEmpty(operatorAddress))
+            {
+                throw new ArgumentException("Operator address must be provided");
+            }
+
+            return await ThirdwebContract.Write(wallet, contract, "setApprovalForAll", 0, operatorAddress, approved);
+        }
+
+        // Transfer a specific token from one address to another
+        public static async Task<TransactionReceipt> ERC721_TransferFrom(this ThirdwebContract contract, IThirdwebWallet wallet, string fromAddress, string toAddress, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (wallet == null)
+            {
+                throw new ArgumentNullException(nameof(wallet));
+            }
+
+            if (string.IsNullOrEmpty(fromAddress))
+            {
+                throw new ArgumentException("Sender address must be provided");
+            }
+
+            if (string.IsNullOrEmpty(toAddress))
+            {
+                throw new ArgumentException("Recipient address must be provided");
+            }
+
+            return await ThirdwebContract.Write(wallet, contract, "transferFrom", 0, fromAddress, toAddress, tokenId);
+        }
+
+        // Safe transfer a specific token from one address to another
+        public static async Task<TransactionReceipt> ERC721_SafeTransferFrom(this ThirdwebContract contract, IThirdwebWallet wallet, string fromAddress, string toAddress, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (wallet == null)
+            {
+                throw new ArgumentNullException(nameof(wallet));
+            }
+
+            if (string.IsNullOrEmpty(fromAddress))
+            {
+                throw new ArgumentException("Sender address must be provided");
+            }
+
+            if (string.IsNullOrEmpty(toAddress))
+            {
+                throw new ArgumentException("Recipient address must be provided");
+            }
+
+            return await ThirdwebContract.Write(wallet, contract, "safeTransferFrom", 0, fromAddress, toAddress, tokenId);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to extend the Thirdweb contract functionality to support ERC721 tokens, including balance checks, ownership, approvals, and transfers.

### Detailed summary
- Added ERC721 extension methods to `ThirdwebContractExtensions.cs`
- Implemented ERC721 extension tests in `ERC721ExtensionTests.cs`

> The following files were skipped due to too many changes: `Thirdweb.Tests/Thirdweb.ERC721Extension.Tests.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->