### PR TITLE
ERC1155 Extensions

### DIFF
--- a/Thirdweb.Tests/Thirdweb.ERC1155Extension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.ERC1155Extension.Tests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Numerics;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Thirdweb.Tests
+{
+    public class ERC1155ExtensionTests : BaseTests
+    {
+        private readonly string _erc1155ContractAddress = "0x83b5851134DAA0E28d855E7fBbdB6B412b46d26B";
+        private readonly BigInteger _chainId = 421614;
+
+        public ERC1155ExtensionTests(ITestOutputHelper output)
+            : base(output) { }
+
+        private async Task<IThirdwebWallet> GetWallet()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var privateKeyWallet = await PrivateKeyWallet.Create(client, _testPrivateKey);
+            var smartAccount = await SmartWallet.Create(client, personalWallet: privateKeyWallet, factoryAddress: "0xbf1C9aA4B1A085f7DA890a44E82B0A1289A40052", gasless: true, chainId: 421614);
+            return smartAccount;
+        }
+
+        [Fact]
+        public async Task NullChecks()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+            var wallet = await GetWallet();
+
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_BalanceOf(null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_BalanceOf(string.Empty, BigInteger.Zero));
+
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_BalanceOfBatch(null, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_BalanceOfBatch(new string[] { }, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_BalanceOfBatch(null, new BigInteger[] { }));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_SetApprovalForAll(null, null, false));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SetApprovalForAll(wallet, null, false));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SetApprovalForAll(wallet, string.Empty, false));
+
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_IsApprovedForAll(null, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_IsApprovedForAll(string.Empty, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_IsApprovedForAll(null, string.Empty));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_SafeTransferFrom(null, null, null, BigInteger.Zero, BigInteger.Zero, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SafeTransferFrom(wallet, null, null, BigInteger.Zero, BigInteger.Zero, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SafeTransferFrom(wallet, string.Empty, null, BigInteger.Zero, BigInteger.Zero, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SafeTransferFrom(wallet, Constants.ADDRESS_ZERO, null, BigInteger.Zero, BigInteger.Zero, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SafeTransferFrom(wallet, Constants.ADDRESS_ZERO, string.Empty, BigInteger.Zero, BigInteger.Zero, null));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_SafeBatchTransferFrom(null, null, null, null, null, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, null, null, new BigInteger[] { }, new BigInteger[] { }, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, string.Empty, null, new BigInteger[] { }, new BigInteger[] { }, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, Constants.ADDRESS_ZERO, null, new BigInteger[] { }, new BigInteger[] { }, null)
+            );
+            _ = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, Constants.ADDRESS_ZERO, string.Empty, new BigInteger[] { }, new BigInteger[] { }, null)
+            );
+
+            contract = null;
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_BalanceOf(Constants.ADDRESS_ZERO, BigInteger.Zero));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_URI(BigInteger.Zero));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_BalanceOfBatch(new string[] { }, new BigInteger[] { }));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_SetApprovalForAll(wallet, Constants.ADDRESS_ZERO, false));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_IsApprovedForAll(null, null));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await contract.ERC1155_SafeTransferFrom(wallet, Constants.ADDRESS_ZERO, Constants.ADDRESS_ZERO, BigInteger.Zero, BigInteger.Zero, null)
+            );
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, Constants.ADDRESS_ZERO, Constants.ADDRESS_ZERO, new BigInteger[] { }, new BigInteger[] { }, null)
+            );
+        }
+
+        [Fact]
+        public async Task ERC1155_BalanceOf()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+            var wallet = await GetWallet();
+            var ownerAddress = await wallet.GetAddress();
+            var tokenId = BigInteger.Parse("1");
+
+            var balance = await contract.ERC1155_BalanceOf(ownerAddress, tokenId);
+
+            Assert.True(balance >= 0);
+        }
+
+        [Fact]
+        public async Task ERC1155_BalanceOfBatch()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+            var wallet = await GetWallet();
+            var ownerAddresses = new string[] { await wallet.GetAddress(), await wallet.GetAddress() };
+            var tokenIds = new BigInteger[] { BigInteger.Parse("1"), BigInteger.Parse("2") };
+
+            var balances = await contract.ERC1155_BalanceOfBatch(ownerAddresses, tokenIds);
+
+            Assert.True(balances.Count == ownerAddresses.Length);
+        }
+
+        [Fact]
+        public async Task ERC1155_IsApprovedForAll()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+            var ownerAddress = Constants.ADDRESS_ZERO;
+            var operatorAddress = contract.Address;
+
+            var isApproved = await contract.ERC1155_IsApprovedForAll(ownerAddress, operatorAddress);
+
+            Assert.True(isApproved || !isApproved);
+        }
+
+        [Fact]
+        public async Task ERC1155_URI()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+            var tokenId = BigInteger.Parse("1");
+
+            var uri = await contract.ERC1155_URI(tokenId);
+
+            Assert.False(string.IsNullOrEmpty(uri));
+        }
+
+        [Fact]
+        public async Task ERC1155_SetApprovalForAll()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+            var wallet = await GetWallet();
+            var operatorAddress = contract.Address;
+            var approved = true;
+
+            var receipt = await contract.ERC1155_SetApprovalForAll(wallet, operatorAddress, approved);
+
+            Assert.True(receipt.TransactionHash.Length == 66);
+        }
+
+        // [Fact]
+        // public async Task ERC1155_SafeTransferFrom()
+        // {
+        //     var client = ThirdwebClient.Create(secretKey: _secretKey);
+        //     var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+        //     var wallet = await GetWallet();
+        //     var fromAddress = await wallet.GetAddress();
+        //     var toAddress = contract.Address;
+        //     var tokenId = BigInteger.Parse("1");
+        //     var amount = BigInteger.Parse("1");
+        //     var data = new byte[] { };
+
+        //     var receipt = await contract.ERC1155_SafeTransferFrom(wallet, fromAddress, toAddress, tokenId, amount, data);
+
+        //     Assert.True(receipt.TransactionHash.Length == 66);
+        // }
+
+        // [Fact]
+        // public async Task ERC1155_SafeBatchTransferFrom()
+        // {
+        //     var client = ThirdwebClient.Create(secretKey: _secretKey);
+        //     var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+        //     var wallet = await GetWallet();
+        //     var fromAddress = await wallet.GetAddress();
+        //     var toAddress = contract.Address;
+        //     var tokenIds = new BigInteger[] { BigInteger.Parse("1"), BigInteger.Parse("2") };
+        //     var amounts = new BigInteger[] { BigInteger.Parse("1"), BigInteger.Parse("1") };
+        //     var data = new byte[] { };
+
+        //     var receipt = await contract.ERC1155_SafeBatchTransferFrom(wallet, fromAddress, toAddress, tokenIds, amounts, data);
+
+        //     Assert.True(receipt.TransactionHash.Length == 66);
+        // }
+    }
+}

--- a/Thirdweb.Tests/Thirdweb.ERC1155Extension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.ERC1155Extension.Tests.cs
@@ -42,7 +42,8 @@ namespace Thirdweb.Tests
 
             _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_IsApprovedForAll(null, null));
             _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_IsApprovedForAll(string.Empty, null));
-            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_IsApprovedForAll(null, string.Empty));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_IsApprovedForAll(Constants.ADDRESS_ZERO, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_IsApprovedForAll(Constants.ADDRESS_ZERO, string.Empty));
 
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_SafeTransferFrom(null, null, null, BigInteger.Zero, BigInteger.Zero, null));
             _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SafeTransferFrom(wallet, null, null, BigInteger.Zero, BigInteger.Zero, null));
@@ -59,6 +60,10 @@ namespace Thirdweb.Tests
             _ = await Assert.ThrowsAsync<ArgumentException>(
                 async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, Constants.ADDRESS_ZERO, string.Empty, new BigInteger[] { }, new BigInteger[] { }, null)
             );
+            _ = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, Constants.ADDRESS_ZERO, Constants.ADDRESS_ZERO, null, new BigInteger[] { }, null)
+            );
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, Constants.ADDRESS_ZERO, string.Empty, new BigInteger[] { }, null, null));
 
             contract = null;
 

--- a/Thirdweb.Tests/Thirdweb.ERC1155Extension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.ERC1155Extension.Tests.cs
@@ -63,7 +63,9 @@ namespace Thirdweb.Tests
             _ = await Assert.ThrowsAsync<ArgumentException>(
                 async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, Constants.ADDRESS_ZERO, Constants.ADDRESS_ZERO, null, new BigInteger[] { }, null)
             );
-            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, Constants.ADDRESS_ZERO, string.Empty, new BigInteger[] { }, null, null));
+            _ = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await contract.ERC1155_SafeBatchTransferFrom(wallet, Constants.ADDRESS_ZERO, Constants.ADDRESS_ZERO, new BigInteger[] { }, null, null)
+            );
 
             contract = null;
 

--- a/Thirdweb.Tests/Thirdweb.ERC721Extension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.ERC721Extension.Tests.cs
@@ -166,6 +166,20 @@ namespace Thirdweb.Tests
             Assert.True(isApproved || !isApproved);
         }
 
+        [Fact]
+        public async Task ERC721_SetApprovalForAll()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+            var wallet = await GetWallet();
+            var operatorAddress = contract.Address;
+            var approved = true;
+
+            var receipt = await contract.ERC721_SetApprovalForAll(wallet, operatorAddress, approved);
+
+            Assert.True(receipt.TransactionHash.Length == 66);
+        }
+
         // [Fact]
         // public async Task ERC721_Approve()
         // {
@@ -177,20 +191,6 @@ namespace Thirdweb.Tests
         //     var tokenId = BigInteger.Parse("1");
 
         //     var receipt = await contract.ERC721_Approve(wallet, toAddress, tokenId);
-
-        //     Assert.True(receipt.TransactionHash.Length == 66);
-        // }
-
-        // [Fact]
-        // public async Task ERC721_SetApprovalForAll()
-        // {
-        //     var client = ThirdwebClient.Create(secretKey: _secretKey);
-        //     var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
-        //     var wallet = await GetWallet();
-        //     var operatorAddress = contract.Address;
-        //     var approved = true;
-
-        //     var receipt = await contract.ERC721_SetApprovalForAll(wallet, operatorAddress, approved);
 
         //     Assert.True(receipt.TransactionHash.Length == 66);
         // }

--- a/Thirdweb/Thirdweb.Contracts/ThirdwebContractExtensions.cs
+++ b/Thirdweb/Thirdweb.Contracts/ThirdwebContractExtensions.cs
@@ -347,5 +347,167 @@ namespace Thirdweb
         }
 
         #endregion
+
+        #region ERC1155
+
+        // Check the balance of a specific token for a specific address
+        public static async Task<BigInteger> ERC1155_BalanceOf(this ThirdwebContract contract, string ownerAddress, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (string.IsNullOrEmpty(ownerAddress))
+            {
+                throw new ArgumentException("Owner address must be provided");
+            }
+
+            return await ThirdwebContract.Read<BigInteger>(contract, "balanceOf", ownerAddress, tokenId);
+        }
+
+        // Check the balance of multiple tokens for multiple addresses
+        public static async Task<List<BigInteger>> ERC1155_BalanceOfBatch(this ThirdwebContract contract, string[] ownerAddresses, BigInteger[] tokenIds)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (ownerAddresses == null || tokenIds == null)
+            {
+                throw new ArgumentException("Owner addresses and token IDs must be provided");
+            }
+
+            return await ThirdwebContract.Read<List<BigInteger>>(contract, "balanceOfBatch", ownerAddresses, tokenIds);
+        }
+
+        // Approve a specific address to transfer specific tokens
+        public static async Task<TransactionReceipt> ERC1155_SetApprovalForAll(this ThirdwebContract contract, IThirdwebWallet wallet, string operatorAddress, bool approved)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (wallet == null)
+            {
+                throw new ArgumentNullException(nameof(wallet));
+            }
+
+            if (string.IsNullOrEmpty(operatorAddress))
+            {
+                throw new ArgumentException("Operator address must be provided");
+            }
+
+            return await ThirdwebContract.Write(wallet, contract, "setApprovalForAll", 0, operatorAddress, approved);
+        }
+
+        // Check if an address is approved to transfer specific tokens
+        public static async Task<bool> ERC1155_IsApprovedForAll(this ThirdwebContract contract, string ownerAddress, string operatorAddress)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (string.IsNullOrEmpty(ownerAddress))
+            {
+                throw new ArgumentException("Owner address must be provided");
+            }
+
+            if (string.IsNullOrEmpty(operatorAddress))
+            {
+                throw new ArgumentException("Operator address must be provided");
+            }
+
+            return await ThirdwebContract.Read<bool>(contract, "isApprovedForAll", ownerAddress, operatorAddress);
+        }
+
+        // Transfer specific tokens from one address to another
+        public static async Task<TransactionReceipt> ERC1155_SafeTransferFrom(
+            this ThirdwebContract contract,
+            IThirdwebWallet wallet,
+            string fromAddress,
+            string toAddress,
+            BigInteger tokenId,
+            BigInteger amount,
+            byte[] data
+        )
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (wallet == null)
+            {
+                throw new ArgumentNullException(nameof(wallet));
+            }
+
+            if (string.IsNullOrEmpty(fromAddress))
+            {
+                throw new ArgumentException("Sender address must be provided");
+            }
+
+            if (string.IsNullOrEmpty(toAddress))
+            {
+                throw new ArgumentException("Recipient address must be provided");
+            }
+
+            return await ThirdwebContract.Write(wallet, contract, "safeTransferFrom", 0, fromAddress, toAddress, tokenId, amount, data);
+        }
+
+        // Transfer multiple tokens from one address to another
+        public static async Task<TransactionReceipt> ERC1155_SafeBatchTransferFrom(
+            this ThirdwebContract contract,
+            IThirdwebWallet wallet,
+            string fromAddress,
+            string toAddress,
+            BigInteger[] tokenIds,
+            BigInteger[] amounts,
+            byte[] data
+        )
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (wallet == null)
+            {
+                throw new ArgumentNullException(nameof(wallet));
+            }
+
+            if (string.IsNullOrEmpty(fromAddress))
+            {
+                throw new ArgumentException("Sender address must be provided");
+            }
+
+            if (string.IsNullOrEmpty(toAddress))
+            {
+                throw new ArgumentException("Recipient address must be provided");
+            }
+
+            if (tokenIds == null || amounts == null)
+            {
+                throw new ArgumentException("Token IDs and amounts must be provided");
+            }
+
+            return await ThirdwebContract.Write(wallet, contract, "safeBatchTransferFrom", 0, fromAddress, toAddress, tokenIds, amounts, data);
+        }
+
+        // Get the URI for a specific token
+        public static async Task<string> ERC1155_URI(this ThirdwebContract contract, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            return await ThirdwebContract.Read<string>(contract, "uri", tokenId);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces ERC1155 extension methods for Thirdweb contracts, including balance checks, approvals, transfers, and URI retrieval.

### Detailed summary
- Added ERC1155 extension methods for Thirdweb contracts
- Included balance checks, approvals, transfers, and URI retrieval
- Added tests for null checks in ERC1155 extension methods

> The following files were skipped due to too many changes: `Thirdweb.Tests/Thirdweb.ERC1155Extension.Tests.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->