### PR TITLE
NFT Extensions + RPC Caching

### DIFF
--- a/Thirdweb.Tests/Thirdweb.CommonExtension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.CommonExtension.Tests.cs
@@ -23,9 +23,6 @@ namespace Thirdweb.Tests
             var client = ThirdwebClient.Create(secretKey: _secretKey);
             var contract = await GetContract();
 
-            client = null;
-            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.GetBalance());
-
             contract = null;
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.GetBalance());
         }

--- a/Thirdweb.Tests/Thirdweb.CommonExtension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.CommonExtension.Tests.cs
@@ -24,10 +24,10 @@ namespace Thirdweb.Tests
             var contract = await GetContract();
 
             client = null;
-            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.GetBalance(client));
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.GetBalance());
 
             contract = null;
-            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.GetBalance(client));
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.GetBalance());
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace Thirdweb.Tests
         {
             var client = ThirdwebClient.Create(secretKey: _secretKey);
             var contract = await GetContract();
-            var balance = await contract.GetBalance(client);
+            var balance = await contract.GetBalance();
             Assert.True(balance >= 0);
         }
     }

--- a/Thirdweb.Tests/Thirdweb.ERC1155Extension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.ERC1155Extension.Tests.cs
@@ -79,6 +79,10 @@ namespace Thirdweb.Tests
 
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_IsApprovedForAll(null, null));
 
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_TotalSupply());
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC1155_TotalSupply(BigInteger.Zero));
+
             _ = await Assert.ThrowsAsync<ArgumentNullException>(
                 async () => await contract.ERC1155_SafeTransferFrom(wallet, Constants.ADDRESS_ZERO, Constants.ADDRESS_ZERO, BigInteger.Zero, BigInteger.Zero, null)
             );
@@ -153,6 +157,29 @@ namespace Thirdweb.Tests
             var receipt = await contract.ERC1155_SetApprovalForAll(wallet, operatorAddress, approved);
 
             Assert.True(receipt.TransactionHash.Length == 66);
+        }
+
+        [Fact]
+        public async Task ERC1155_TotalSupply()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+
+            var totalSupply = await contract.ERC1155_TotalSupply();
+
+            Assert.True(totalSupply >= 0);
+        }
+
+        [Fact]
+        public async Task ERC1155_TotalSupply_WithTokenId()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+            var tokenId = BigInteger.Parse("1");
+
+            var totalSupply = await contract.ERC1155_TotalSupply(tokenId);
+
+            Assert.True(totalSupply >= 0);
         }
 
         // TODO: Update when mint implemented

--- a/Thirdweb.Tests/Thirdweb.ERC721Extension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.ERC721Extension.Tests.cs
@@ -57,6 +57,9 @@ namespace Thirdweb.Tests
             _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_SetApprovalForAll(wallet, null, false));
             _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_SetApprovalForAll(wallet, string.Empty, false));
 
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_TokenOfOwnerByIndex(null, BigInteger.Zero));
+            _ = await Assert.ThrowsAsync<ArgumentException>(async () => await contract.ERC721_TokenOfOwnerByIndex(string.Empty, BigInteger.Zero));
+
             contract = null;
 
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_BalanceOf(Constants.ADDRESS_ZERO));
@@ -80,6 +83,10 @@ namespace Thirdweb.Tests
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_SafeTransferFrom(null, null, null, BigInteger.Zero));
 
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_Approve(null, null, BigInteger.Zero));
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_TotalSupply());
+
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract.ERC721_TokenOfOwnerByIndex(Constants.ADDRESS_ZERO, BigInteger.Zero));
         }
 
         [Fact]
@@ -164,6 +171,30 @@ namespace Thirdweb.Tests
             var isApproved = await contract.ERC721_IsApprovedForAll(ownerAddress, operatorAddress);
 
             Assert.True(isApproved || !isApproved);
+        }
+
+        [Fact]
+        public async Task ERC721_TotalSupply()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+
+            var totalSupply = await contract.ERC721_TotalSupply();
+
+            Assert.True(totalSupply >= 0);
+        }
+
+        [Fact]
+        public async Task ERC721_TokenOfOwnerByIndex()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+            var ownerAddress = "0xE33653ce510Ee767d8824b5EcDeD27125D49889D";
+            var index = BigInteger.Zero;
+
+            var tokenId = await contract.ERC721_TokenOfOwnerByIndex(ownerAddress, index);
+
+            Assert.True(tokenId >= 0);
         }
 
         [Fact]

--- a/Thirdweb.Tests/Thirdweb.NFTExtension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.NFTExtension.Tests.cs
@@ -83,6 +83,16 @@ namespace Thirdweb.Tests
         }
 
         [Fact]
+        public async Task GetAllNFTs_721_WithRange()
+        {
+            var contract = await Get721Contract();
+            var nfts = await contract.ERC721_GetAllNFTs(1, 2);
+            Assert.NotNull(nfts);
+            Assert.NotEmpty(nfts);
+            Assert.True(nfts.Count == 1);
+        }
+
+        [Fact]
         public async Task GetOwnedNFTs_721()
         {
             var contract = await Get721Contract();
@@ -107,6 +117,16 @@ namespace Thirdweb.Tests
             var nfts = await contract.ERC1155_GetAllNFTs();
             Assert.NotNull(nfts);
             Assert.NotEmpty(nfts);
+        }
+
+        [Fact]
+        public async Task GetAllNFTs_1155_WithRange()
+        {
+            var contract = await Get1155Contract();
+            var nfts = await contract.ERC1155_GetAllNFTs(1, 2);
+            Assert.NotNull(nfts);
+            Assert.NotEmpty(nfts);
+            Assert.True(nfts.Count == 1);
         }
 
         [Fact]

--- a/Thirdweb.Tests/Thirdweb.NFTExtension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.NFTExtension.Tests.cs
@@ -1,0 +1,65 @@
+using System.Numerics;
+
+namespace Thirdweb.Tests
+{
+    public class NFTExtensionTests : BaseTests
+    {
+        private readonly string _erc721ContractAddress = "0xD811CB13169C175b64bf8897e2Fd6a69C6343f5C";
+        private readonly string _erc1155ContractAddress = "0x6A7a26c9a595E6893C255C9dF0b593e77518e0c3";
+        private readonly BigInteger _chainId = 421614;
+
+        public NFTExtensionTests(ITestOutputHelper output)
+            : base(output) { }
+
+        private async Task<ThirdwebContract> Get721Contract()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc721ContractAddress, _chainId);
+            return contract;
+        }
+
+        private async Task<ThirdwebContract> Get1155Contract()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract = await ThirdwebContract.Create(client, _erc1155ContractAddress, _chainId);
+            return contract;
+        }
+
+        [Fact]
+        public async Task NullChecks()
+        {
+            var client = ThirdwebClient.Create(secretKey: _secretKey);
+            var contract721 = await Get721Contract();
+            var contract1155 = await Get1155Contract();
+
+            contract721 = null;
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract721.ERC721_GetNFT(0));
+
+            // TODO: Add more null checks
+        }
+
+        [Fact]
+        public async Task GetNFTBytes_721()
+        {
+            var contract = await Get721Contract();
+            var nft = await contract.ERC721_GetNFT(0);
+            var bytes = await nft.GetNFTImageBytes(contract.Client);
+            Assert.NotNull(bytes);
+            Assert.NotEmpty(bytes);
+        }
+
+        [Fact]
+        public async Task GetNFT_721()
+        {
+            var contract = await Get721Contract();
+            var nft = await contract.ERC721_GetNFT(0);
+            Assert.NotNull(nft.Owner);
+            Assert.NotEmpty(nft.Owner);
+            Assert.Equal(NFTType.ERC721, nft.Type);
+            Assert.True(nft.Supply == -1 || nft.Supply > 0);
+            Assert.True(nft.QuantityOwned == -1);
+        }
+
+        // TODO: Add more tests
+    }
+}

--- a/Thirdweb.Tests/Thirdweb.NFTExtension.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.NFTExtension.Tests.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Collections.Generic;
 using System.Numerics;
+using System.Threading.Tasks;
+using Thirdweb;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Thirdweb.Tests
 {
@@ -32,10 +38,17 @@ namespace Thirdweb.Tests
             var contract721 = await Get721Contract();
             var contract1155 = await Get1155Contract();
 
+            // ERC721 Null Checks
             contract721 = null;
             _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract721.ERC721_GetNFT(0));
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract721.ERC721_GetAllNFTs());
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract721.ERC721_GetOwnedNFTs("owner"));
 
-            // TODO: Add more null checks
+            // ERC1155 Null Checks
+            contract1155 = null;
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract1155.ERC1155_GetNFT(0));
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract1155.ERC1155_GetAllNFTs());
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await contract1155.ERC1155_GetOwnedNFTs("owner"));
         }
 
         [Fact]
@@ -60,6 +73,49 @@ namespace Thirdweb.Tests
             Assert.True(nft.QuantityOwned == -1);
         }
 
-        // TODO: Add more tests
+        [Fact]
+        public async Task GetAllNFTs_721()
+        {
+            var contract = await Get721Contract();
+            var nfts = await contract.ERC721_GetAllNFTs();
+            Assert.NotNull(nfts);
+            Assert.NotEmpty(nfts);
+        }
+
+        [Fact]
+        public async Task GetOwnedNFTs_721()
+        {
+            var contract = await Get721Contract();
+            var ownerAddress = contract.Address;
+            var nfts = await contract.ERC721_GetOwnedNFTs(ownerAddress);
+            Assert.NotNull(nfts);
+        }
+
+        [Fact]
+        public async Task GetNFT_1155()
+        {
+            var contract = await Get1155Contract();
+            var nft = await contract.ERC1155_GetNFT(0);
+            Assert.Equal(NFTType.ERC1155, nft.Type);
+            Assert.True(nft.Supply >= 0);
+        }
+
+        [Fact]
+        public async Task GetAllNFTs_1155()
+        {
+            var contract = await Get1155Contract();
+            var nfts = await contract.ERC1155_GetAllNFTs();
+            Assert.NotNull(nfts);
+            Assert.NotEmpty(nfts);
+        }
+
+        [Fact]
+        public async Task GetOwnedNFTs_1155()
+        {
+            var contract = await Get1155Contract();
+            var ownerAddress = contract.Address;
+            var nfts = await contract.ERC1155_GetOwnedNFTs(ownerAddress);
+            Assert.NotNull(nfts);
+        }
     }
 }

--- a/Thirdweb/Thirdweb.Contracts/ThirdwebContractExtensions.cs
+++ b/Thirdweb/Thirdweb.Contracts/ThirdwebContractExtensions.cs
@@ -593,17 +593,6 @@ namespace Thirdweb
             }
         }
 
-        // Exists
-        public static async Task<bool> ERC1155_Exists(this ThirdwebContract contract, BigInteger tokenId)
-        {
-            if (contract == null)
-            {
-                throw new ArgumentNullException(nameof(contract));
-            }
-
-            return await ThirdwebContract.Read<bool>(contract, "exists", tokenId);
-        }
-
         #endregion
     }
 }

--- a/Thirdweb/Thirdweb.Contracts/ThirdwebContractExtensions.cs
+++ b/Thirdweb/Thirdweb.Contracts/ThirdwebContractExtensions.cs
@@ -16,12 +16,6 @@ namespace Thirdweb
             }
 
             var client = contract.Client;
-
-            if (client == null)
-            {
-                throw new ArgumentException("Client must be provided");
-            }
-
             var rpc = ThirdwebRPC.GetRpcInstance(client, contract.Chain);
             var balanceHex = await rpc.SendRequestAsync<string>("eth_getBalance", contract.Address, "latest");
             return new HexBigInteger(balanceHex).Value;

--- a/Thirdweb/Thirdweb.Contracts/ThirdwebContractExtensions.cs
+++ b/Thirdweb/Thirdweb.Contracts/ThirdwebContractExtensions.cs
@@ -8,16 +8,18 @@ namespace Thirdweb
     {
         #region Common
 
-        public static async Task<BigInteger> GetBalance(this ThirdwebContract contract, ThirdwebClient client)
+        public static async Task<BigInteger> GetBalance(this ThirdwebContract contract)
         {
             if (contract == null)
             {
                 throw new ArgumentNullException(nameof(contract));
             }
 
+            var client = contract.Client;
+
             if (client == null)
             {
-                throw new ArgumentNullException(nameof(client));
+                throw new ArgumentException("Client must be provided");
             }
 
             var rpc = ThirdwebRPC.GetRpcInstance(client, contract.Chain);
@@ -176,6 +178,44 @@ namespace Thirdweb
             }
 
             return await ThirdwebContract.Write(wallet, contract, "transferFrom", 0, fromAddress, toAddress, amount);
+        }
+
+        // Total supply of the token
+        public static async Task<BigInteger> ERC721_TotalSupply(this ThirdwebContract contract)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            return await ThirdwebContract.Read<BigInteger>(contract, "totalSupply");
+        }
+
+        // Get the token ID of a specific owner by index
+        public static async Task<BigInteger> ERC721_TokenOfOwnerByIndex(this ThirdwebContract contract, string ownerAddress, BigInteger index)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (string.IsNullOrEmpty(ownerAddress))
+            {
+                throw new ArgumentException("Owner address must be provided");
+            }
+
+            return await ThirdwebContract.Read<BigInteger>(contract, "tokenOfOwnerByIndex", ownerAddress, index);
+        }
+
+        // Get the token ID of a specific owner by index
+        public static async Task<BigInteger> ERC721_TokenByIndex(this ThirdwebContract contract, BigInteger index)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            return await ThirdwebContract.Read<BigInteger>(contract, "tokenByIndex", index);
         }
 
         #endregion
@@ -528,6 +568,46 @@ namespace Thirdweb
             }
 
             return await ThirdwebContract.Read<string>(contract, "uri", tokenId);
+        }
+
+        // Total Supply of id
+        public static async Task<BigInteger> ERC1155_TotalSupply(this ThirdwebContract contract, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            return await ThirdwebContract.Read<BigInteger>(contract, "totalSupply", tokenId);
+        }
+
+        // Total Supply
+        public static async Task<BigInteger> ERC1155_TotalSupply(this ThirdwebContract contract)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            try
+            {
+                return await ThirdwebContract.Read<BigInteger>(contract, "nextTokenIdToMint");
+            }
+            catch (Exception)
+            {
+                return await ThirdwebContract.Read<BigInteger>(contract, "totalSupply");
+            }
+        }
+
+        // Exists
+        public static async Task<bool> ERC1155_Exists(this ThirdwebContract contract, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            return await ThirdwebContract.Read<bool>(contract, "exists", tokenId);
         }
 
         #endregion

--- a/Thirdweb/Thirdweb.NFT/NFTTypes.cs
+++ b/Thirdweb/Thirdweb.NFT/NFTTypes.cs
@@ -1,0 +1,47 @@
+using System.Numerics;
+using Newtonsoft.Json;
+
+namespace Thirdweb
+{
+    [Serializable]
+    public enum NFTType
+    {
+        ERC721,
+        ERC1155
+    }
+
+    [Serializable]
+    public struct NFT
+    {
+        public NFTMetadata Metadata { get; set; }
+        public string Owner { get; set; }
+        public NFTType Type { get; set; }
+        public BigInteger Supply { get; set; }
+        public BigInteger? QuantityOwned { get; set; }
+    }
+
+    [Serializable]
+    public struct NFTMetadata
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("image")]
+        public string Image { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("external_url")]
+        public string External_url { get; set; }
+
+        [JsonProperty("attributes")]
+        public object Attributes { get; set; }
+    }
+}

--- a/Thirdweb/Thirdweb.NFT/ThirdwebNFTExtensions.cs
+++ b/Thirdweb/Thirdweb.NFT/ThirdwebNFTExtensions.cs
@@ -1,0 +1,200 @@
+using System.Numerics;
+
+namespace Thirdweb
+{
+    public static class ThirdwebNFTExtensions
+    {
+        #region  Common
+
+        public static async Task<byte[]> GetNFTImageBytes(this NFT nft, ThirdwebClient client)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            return await ThirdwebStorage.Download<byte[]>(client, nft.Metadata.Image);
+        }
+
+        #endregion
+
+        #region ERC721
+
+        public static async Task<NFT> ERC721_GetNFT(this ThirdwebContract contract, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            var uri = await contract.ERC721_TokenURI(tokenId);
+            var metadata = await ThirdwebStorage.Download<NFTMetadata>(contract.Client, uri);
+            var owner = await contract.ERC721_OwnerOf(tokenId);
+            var supply = -BigInteger.MinusOne;
+            try
+            {
+                supply = await contract.ERC721_TotalSupply();
+            }
+            catch (Exception)
+            {
+                supply = -1;
+            }
+            var quantityOwned = -1;
+
+            return new NFT
+            {
+                Metadata = metadata,
+                Owner = owner,
+                Type = NFTType.ERC721,
+                Supply = supply,
+                QuantityOwned = quantityOwned
+            };
+        }
+
+        public static async Task<List<NFT>> ERC721_GetAllNFTs(this ThirdwebContract contract)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            var totalSupply = await contract.ERC721_TotalSupply();
+            var nfts = new List<NFT>();
+
+            for (var i = 0; i < totalSupply; i++)
+            {
+                var nft = await contract.ERC721_GetNFT(i);
+                nfts.Add(nft);
+            }
+
+            return nfts;
+        }
+
+        public static async Task<List<NFT>> ERC721_GetOwnedNFTs(this ThirdwebContract contract, string owner)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (string.IsNullOrEmpty(owner))
+            {
+                throw new ArgumentException("Owner must be provided");
+            }
+
+            var nfts = new List<NFT>();
+
+            var totalSupply = await contract.ERC721_TotalSupply();
+
+            try
+            {
+                var balanceOfOwner = await contract.ERC721_BalanceOf(owner);
+                for (var i = 0; i < balanceOfOwner; i++)
+                {
+                    var tokenOfOwnerByIndex = await contract.ERC721_TokenOfOwnerByIndex(owner, i);
+                    var nft = await contract.ERC721_GetNFT(tokenOfOwnerByIndex);
+                    nfts.Add(nft);
+                }
+            }
+            catch (Exception)
+            {
+                nfts = new List<NFT>();
+                for (var i = 0; i < totalSupply; i++)
+                {
+                    var nft = await contract.ERC721_GetNFT(i);
+                    if (nft.Owner == owner)
+                    {
+                        nfts.Add(nft);
+                    }
+                }
+            }
+
+            return nfts;
+        }
+
+        #endregion
+
+        #region ERC1155
+
+        public static async Task<NFT> ERC1155_GetNFT(this ThirdwebContract contract, BigInteger tokenId)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            var uri = await contract.ERC1155_URI(tokenId);
+            var metadata = await ThirdwebStorage.Download<NFTMetadata>(contract.Client, uri);
+            var owner = string.Empty;
+            var supply = BigInteger.MinusOne;
+            try
+            {
+                supply = await contract.ERC1155_TotalSupply(tokenId);
+            }
+            catch (Exception)
+            {
+                supply = BigInteger.MinusOne;
+            }
+            var quantityOwned = BigInteger.MinusOne;
+
+            return new NFT
+            {
+                Metadata = metadata,
+                Owner = owner,
+                Type = NFTType.ERC1155,
+                Supply = supply,
+                QuantityOwned = quantityOwned
+            };
+        }
+
+        public static async Task<List<NFT>> ERC1155_GetAllNFTs(this ThirdwebContract contract)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            var totalSupply = await contract.ERC1155_TotalSupply();
+            var nfts = new List<NFT>();
+
+            for (var i = 0; i < totalSupply; i++)
+            {
+                var nft = await contract.ERC1155_GetNFT(i);
+                nfts.Add(nft);
+            }
+
+            return nfts;
+        }
+
+        public static async Task<List<NFT>> ERC1155_GetOwnedNFTs(this ThirdwebContract contract, string owner)
+        {
+            if (contract == null)
+            {
+                throw new ArgumentNullException(nameof(contract));
+            }
+
+            if (string.IsNullOrEmpty(owner))
+            {
+                throw new ArgumentException("Owner must be provided");
+            }
+
+            var totalSupply = await contract.ERC1155_TotalSupply();
+
+            var nfts = new List<NFT>();
+            for (var i = 0; i < totalSupply; i++)
+            {
+                var balanceOfOwner = await contract.ERC1155_BalanceOf(owner, i);
+                if (balanceOfOwner > 0)
+                {
+                    var nft = await contract.ERC1155_GetNFT(i);
+                    nft.QuantityOwned = balanceOfOwner;
+                    nfts.Add(nft);
+                }
+            }
+
+            return nfts;
+        }
+
+        #endregion
+    }
+}

--- a/Thirdweb/Thirdweb.NFT/ThirdwebNFTExtensions.cs
+++ b/Thirdweb/Thirdweb.NFT/ThirdwebNFTExtensions.cs
@@ -29,6 +29,7 @@ namespace Thirdweb
 
             var uri = await contract.ERC721_TokenURI(tokenId);
             var metadata = await ThirdwebStorage.Download<NFTMetadata>(contract.Client, uri);
+            metadata.Id = tokenId.ToString();
             var owner = await contract.ERC721_OwnerOf(tokenId);
             var supply = -BigInteger.MinusOne;
             try
@@ -125,6 +126,7 @@ namespace Thirdweb
 
             var uri = await contract.ERC1155_URI(tokenId);
             var metadata = await ThirdwebStorage.Download<NFTMetadata>(contract.Client, uri);
+            metadata.Id = tokenId.ToString();
             var owner = string.Empty;
             var supply = BigInteger.MinusOne;
             try

--- a/Thirdweb/Thirdweb.NFT/ThirdwebNFTExtensions.cs
+++ b/Thirdweb/Thirdweb.NFT/ThirdwebNFTExtensions.cs
@@ -58,17 +58,27 @@ namespace Thirdweb
             };
         }
 
-        public static async Task<List<NFT>> ERC721_GetAllNFTs(this ThirdwebContract contract)
+        public static async Task<List<NFT>> ERC721_GetAllNFTs(this ThirdwebContract contract, BigInteger? startTokenIdIncluded = null, BigInteger? endTokenIdExcluded = null)
         {
             if (contract == null)
             {
                 throw new ArgumentNullException(nameof(contract));
             }
 
-            var totalSupply = await contract.ERC721_TotalSupply();
             var nfts = new List<NFT>();
 
-            for (var i = 0; i < totalSupply; i++)
+            if (startTokenIdIncluded == null)
+            {
+                startTokenIdIncluded = 0;
+            }
+
+            if (endTokenIdExcluded == null)
+            {
+                var totalSupply = await contract.ERC721_TotalSupply();
+                endTokenIdExcluded = totalSupply;
+            }
+
+            for (var i = startTokenIdIncluded.Value; i < endTokenIdExcluded.Value; i++)
             {
                 var nft = await contract.ERC721_GetNFT(i);
                 nfts.Add(nft);
@@ -155,17 +165,27 @@ namespace Thirdweb
             };
         }
 
-        public static async Task<List<NFT>> ERC1155_GetAllNFTs(this ThirdwebContract contract)
+        public static async Task<List<NFT>> ERC1155_GetAllNFTs(this ThirdwebContract contract, BigInteger? startTokenIdIncluded = null, BigInteger? endTokenIdExcluded = null)
         {
             if (contract == null)
             {
                 throw new ArgumentNullException(nameof(contract));
             }
 
-            var totalSupply = await contract.ERC1155_TotalSupply();
             var nfts = new List<NFT>();
 
-            for (var i = 0; i < totalSupply; i++)
+            if (startTokenIdIncluded == null)
+            {
+                startTokenIdIncluded = 0;
+            }
+
+            if (endTokenIdExcluded == null)
+            {
+                var totalSupply = await contract.ERC1155_TotalSupply();
+                endTokenIdExcluded = totalSupply;
+            }
+
+            for (var i = startTokenIdIncluded.Value; i < endTokenIdExcluded.Value; i++)
             {
                 var nft = await contract.ERC1155_GetNFT(i);
                 nfts.Add(nft);

--- a/Thirdweb/Thirdweb.NFT/ThirdwebNFTExtensions.cs
+++ b/Thirdweb/Thirdweb.NFT/ThirdwebNFTExtensions.cs
@@ -8,11 +8,6 @@ namespace Thirdweb
 
         public static async Task<byte[]> GetNFTImageBytes(this NFT nft, ThirdwebClient client)
         {
-            if (client == null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
             return await ThirdwebStorage.Download<byte[]>(client, nft.Metadata.Image);
         }
 
@@ -30,7 +25,17 @@ namespace Thirdweb
             var uri = await contract.ERC721_TokenURI(tokenId);
             var metadata = await ThirdwebStorage.Download<NFTMetadata>(contract.Client, uri);
             metadata.Id = tokenId.ToString();
-            var owner = await contract.ERC721_OwnerOf(tokenId);
+
+            var owner = Constants.ADDRESS_ZERO;
+            try
+            {
+                owner = await contract.ERC721_OwnerOf(tokenId);
+            }
+            catch (Exception)
+            {
+                owner = Constants.ADDRESS_ZERO;
+            }
+
             var supply = -BigInteger.MinusOne;
             try
             {
@@ -40,6 +45,7 @@ namespace Thirdweb
             {
                 supply = -1;
             }
+
             var quantityOwned = -1;
 
             return new NFT


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add NFT-related functionalities such as `NFTType`, `NFT`, and `NFTMetadata` structs, along with ERC721 and ERC1155 extensions for total supply and token retrieval.

### Detailed summary
- Added `NFTType`, `NFT`, and `NFTMetadata` structs
- Included ERC721 and ERC1155 extensions for total supply and token retrieval
- Updated null checks and tests for ERC721 and ERC1155 extensions

> The following files were skipped due to too many changes: `Thirdweb.Tests/Thirdweb.NFTExtension.Tests.cs`, `Thirdweb/Thirdweb.NFT/ThirdwebNFTExtensions.cs`, `Thirdweb/Thirdweb.RPC/ThirdwebRPC.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->