### PR TITLE
IThirdwebWallet.RecoverAddress Variants

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: build-and-test-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   build-test-cov:
     runs-on: ubuntu-latest

--- a/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.Wallets.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.Wallets.Tests.cs
@@ -201,4 +201,42 @@ public class WalletTests : BaseTests
         var recoveredAddress = await wallet.RecoverAddressFromPersonalSign(message, signature);
         Assert.NotEqual(await wallet.GetAddress(), recoveredAddress);
     }
+
+    [Fact(Timeout = 120000)]
+    public async Task RecoverAddress_AllVariants_NullTests()
+    {
+        var wallet = await PrivateKeyWallet.Generate(_client);
+        var message = "Hello, world!";
+        var signature = await wallet.PersonalSign(message);
+
+        _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await wallet.RecoverAddressFromEthSign(null, signature));
+        _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await wallet.RecoverAddressFromEthSign(message, null));
+        _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await wallet.RecoverAddressFromPersonalSign(null, signature));
+        _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await wallet.RecoverAddressFromPersonalSign(message, null));
+
+#nullable disable
+        var nullData = null as AccountAbstraction.SignerPermissionRequest;
+        var nullTypedData = null as Nethereum.ABI.EIP712.TypedData<Nethereum.ABI.EIP712.Domain>;
+        var nullSig = null as string;
+        _ = await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await wallet.RecoverAddressFromTypedDataV4<AccountAbstraction.SignerPermissionRequest, Nethereum.ABI.EIP712.Domain>(nullData, nullTypedData, nullSig)
+        );
+        _ = await Assert.ThrowsAsync<ArgumentNullException>(
+            async () =>
+                await wallet.RecoverAddressFromTypedDataV4<AccountAbstraction.SignerPermissionRequest, Nethereum.ABI.EIP712.Domain>(
+                    new AccountAbstraction.SignerPermissionRequest(),
+                    nullTypedData,
+                    nullSig
+                )
+        );
+        _ = await Assert.ThrowsAsync<ArgumentNullException>(
+            async () =>
+                await wallet.RecoverAddressFromTypedDataV4<AccountAbstraction.SignerPermissionRequest, Nethereum.ABI.EIP712.Domain>(
+                    new AccountAbstraction.SignerPermissionRequest(),
+                    new Nethereum.ABI.EIP712.TypedData<Nethereum.ABI.EIP712.Domain>(),
+                    nullSig
+                )
+        );
+#nullable restore
+    }
 }

--- a/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.Wallets.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.Wallets.Tests.cs
@@ -110,14 +110,6 @@ public class WalletTests : BaseTests
 
         var gen2 = await EIP712.GenerateSignature_SmartAccount("Account", "1", 421614, await wallet.GetAddress(), req, signerAcc);
         Assert.Equal(gen2, signature2);
-
-        // Recover address
-        var recoveredAddress = await wallet.RecoverAddressFromTypedDataV4(req, typedData2, signature2);
-        Assert.Equal(await wallet.GetAddress(), recoveredAddress);
-
-        // Recover address invalid
-        var recoveredAddress2 = await wallet.RecoverAddressFromTypedDataV4(req, typedData2, signature2 + "00");
-        Assert.NotEqual(await wallet.GetAddress(), recoveredAddress2);
     }
 
     [Fact(Timeout = 120000)]
@@ -166,6 +158,17 @@ public class WalletTests : BaseTests
         var message = "Hello, world!";
         var signature = await wallet.PersonalSign(message);
         var recoveredAddress = await wallet.RecoverAddressFromPersonalSign(message, signature);
+        Assert.Equal(await wallet.GetAddress(), recoveredAddress);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task RecoverAddressFromSignTypedDataV4_ReturnsSameAddress()
+    {
+        var wallet = await PrivateKeyWallet.Generate(_client);
+        var typedData = EIP712.GetTypedDefinition_SmartAccount_AccountMessage("Account", "1", 421614, await wallet.GetAddress());
+        var accountMessage = new AccountAbstraction.AccountMessage { Message = System.Text.Encoding.UTF8.GetBytes("Hello, world!").HashPrefixedMessage() };
+        var signature = await wallet.SignTypedDataV4(accountMessage, typedData);
+        var recoveredAddress = await wallet.RecoverAddressFromTypedDataV4<AccountAbstraction.AccountMessage, Nethereum.ABI.EIP712.Domain>(accountMessage, typedData, signature);
         Assert.Equal(await wallet.GetAddress(), recoveredAddress);
     }
 

--- a/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
@@ -42,8 +42,8 @@ namespace Thirdweb
         /// <summary>
         /// Recovers the address from a signed message using Ethereum's signing method.
         /// </summary>
-        /// <param name="message"></param>
-        /// <param name="signature"></param>
+        /// <param name="message">The UTF-8 encoded message.</param>
+        /// <param name="signature">The signature.</param>
         /// <returns>The recovered address.</returns>
         Task<string> RecoverAddressFromEthSign(string message, string signature);
 
@@ -64,8 +64,8 @@ namespace Thirdweb
         /// <summary>
         /// Recovers the address from a signed message using personal signing.
         /// </summary>
-        /// <param name="message"></param>
-        /// <param name="signature"></param>
+        /// <param name="message">The UTF-8 encoded and prefixed message.</param>
+        /// <param name="signature">The signature.</param>
         /// <returns></returns>
         Task<string> RecoverAddressFromPersonalSign(string message, string signature);
 
@@ -92,9 +92,9 @@ namespace Thirdweb
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <typeparam name="TDomain"></typeparam>
-        /// <param name="data"></param>
-        /// <param name="typedData"></param>
-        /// <param name="signature"></param>
+        /// <param name="data">The data to sign.</param>
+        /// <param name="typedData">The typed data.</param>
+        /// <param name="signature">The signature.</param>
         /// <returns></returns>
         Task<string> RecoverAddressFromTypedDataV4<T, TDomain>(T data, TypedData<TDomain> typedData, string signature)
             where TDomain : IDomain;

--- a/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
@@ -66,7 +66,7 @@ namespace Thirdweb
         /// </summary>
         /// <param name="message">The UTF-8 encoded and prefixed message.</param>
         /// <param name="signature">The signature.</param>
-        /// <returns></returns>
+        /// <returns>The recovered address.</returns>
         Task<string> RecoverAddressFromPersonalSign(string message, string signature);
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Thirdweb
         /// <param name="data">The data to sign.</param>
         /// <param name="typedData">The typed data.</param>
         /// <param name="signature">The signature.</param>
-        /// <returns></returns>
+        /// <returns>The recovered address.</returns>
         Task<string> RecoverAddressFromTypedDataV4<T, TDomain>(T data, TypedData<TDomain> typedData, string signature)
             where TDomain : IDomain;
 

--- a/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
@@ -40,6 +40,14 @@ namespace Thirdweb
         Task<string> EthSign(string message);
 
         /// <summary>
+        /// Recovers the address from a signed message using Ethereum's signing method.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="signature"></param>
+        /// <returns>The recovered address.</returns>
+        Task<string> RecoverAddressFromEthSign(string message, string signature);
+
+        /// <summary>
         /// Signs a raw message using personal signing.
         /// </summary>
         /// <param name="rawMessage">The raw message to sign.</param>
@@ -52,6 +60,14 @@ namespace Thirdweb
         /// <param name="message">The message to sign.</param>
         /// <returns>The signed message.</returns>
         Task<string> PersonalSign(string message);
+
+        /// <summary>
+        /// Recovers the address from a signed message using personal signing.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="signature"></param>
+        /// <returns></returns>
+        Task<string> RecoverAddressFromPersonalSign(string message, string signature);
 
         /// <summary>
         /// Signs typed data (version 4).
@@ -69,6 +85,18 @@ namespace Thirdweb
         /// <param name="typedData">The typed data.</param>
         /// <returns>The signed data.</returns>
         Task<string> SignTypedDataV4<T, TDomain>(T data, TypedData<TDomain> typedData)
+            where TDomain : IDomain;
+
+        /// <summary>
+        /// Recovers the address from a signed message using typed data (version 4).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TDomain"></typeparam>
+        /// <param name="data"></param>
+        /// <param name="typedData"></param>
+        /// <param name="signature"></param>
+        /// <returns></returns>
+        Task<string> RecoverAddressFromTypedDataV4<T, TDomain>(T data, TypedData<TDomain> typedData, string signature)
             where TDomain : IDomain;
 
         /// <summary>

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -108,6 +108,30 @@ namespace Thirdweb
         }
 
         /// <summary>
+        /// Recovers the address from a signed message using Ethereum's signing method.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="signature"></param>
+        /// <returns>The recovered address.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public virtual Task<string> RecoverAddressFromEthSign(string message, string signature)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message), "Message to sign cannot be null.");
+            }
+
+            if (signature == null)
+            {
+                throw new ArgumentNullException(nameof(signature), "Signature cannot be null.");
+            }
+
+            var signer = new MessageSigner();
+            var address = signer.HashAndEcRecover(message, signature);
+            return Task.FromResult(address);
+        }
+
+        /// <summary>
         /// Signs a message using the wallet's private key with personal sign.
         /// </summary>
         /// <param name="rawMessage">The message to sign.</param>
@@ -139,6 +163,30 @@ namespace Thirdweb
             var signer = new EthereumMessageSigner();
             var signature = signer.EncodeUTF8AndSign(message, _ecKey);
             return Task.FromResult(signature);
+        }
+
+        /// <summary>
+        /// Recovers the address from a signed message using personal signing.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="signature"></param>
+        /// <returns>The recovered address.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public virtual Task<string> RecoverAddressFromPersonalSign(string message, string signature)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                throw new ArgumentNullException(nameof(message), "Message to sign cannot be null.");
+            }
+
+            if (string.IsNullOrEmpty(signature))
+            {
+                throw new ArgumentNullException(nameof(signature), "Signature cannot be null.");
+            }
+
+            var signer = new EthereumMessageSigner();
+            var address = signer.EncodeUTF8AndEcRecover(message, signature);
+            return Task.FromResult(address);
         }
 
         /// <summary>
@@ -177,6 +225,39 @@ namespace Thirdweb
             var signer = new Eip712TypedDataSigner();
             var signature = signer.SignTypedDataV4(data, typedData, _ecKey);
             return Task.FromResult(signature);
+        }
+
+        /// <summary>
+        /// Recovers the address from a signed message using typed data (version 4).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TDomain"></typeparam>
+        /// <param name="data"></param>
+        /// <param name="typedData"></param>
+        /// <param name="signature"></param>
+        /// <returns>The recovered address.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public virtual Task<string> RecoverAddressFromTypedDataV4<T, TDomain>(T data, TypedData<TDomain> typedData, string signature)
+            where TDomain : IDomain
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data), "Data to sign cannot be null.");
+            }
+
+            if (typedData == null)
+            {
+                throw new ArgumentNullException(nameof(typedData), "Typed data cannot be null.");
+            }
+
+            if (signature == null)
+            {
+                throw new ArgumentNullException(nameof(signature), "Signature cannot be null.");
+            }
+
+            var signer = new Eip712TypedDataSigner();
+            var address = signer.RecoverFromSignatureV4(data, typedData, signature);
+            return Task.FromResult(address);
         }
 
         /// <summary>

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -110,8 +110,8 @@ namespace Thirdweb
         /// <summary>
         /// Recovers the address from a signed message using Ethereum's signing method.
         /// </summary>
-        /// <param name="message"></param>
-        /// <param name="signature"></param>
+        /// <param name="message">The UTF-8 encoded message.</param>
+        /// <param name="signature">The signature.</param>
         /// <returns>The recovered address.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         public virtual Task<string> RecoverAddressFromEthSign(string message, string signature)
@@ -127,7 +127,7 @@ namespace Thirdweb
             }
 
             var signer = new MessageSigner();
-            var address = signer.HashAndEcRecover(message, signature);
+            var address = signer.EcRecover(Encoding.UTF8.GetBytes(message), signature);
             return Task.FromResult(address);
         }
 
@@ -168,8 +168,8 @@ namespace Thirdweb
         /// <summary>
         /// Recovers the address from a signed message using personal signing.
         /// </summary>
-        /// <param name="message"></param>
-        /// <param name="signature"></param>
+        /// <param name="message">The UTF-8 encoded and prefixed message.</param>
+        /// <param name="signature">The signature.</param>
         /// <returns>The recovered address.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         public virtual Task<string> RecoverAddressFromPersonalSign(string message, string signature)
@@ -232,9 +232,9 @@ namespace Thirdweb
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <typeparam name="TDomain"></typeparam>
-        /// <param name="data"></param>
-        /// <param name="typedData"></param>
-        /// <param name="signature"></param>
+        /// <param name="data">The data to sign.</param>
+        /// <param name="typedData">The typed data.</param>
+        /// <param name="signature">The signature.</param>
         /// <returns>The recovered address.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         public virtual Task<string> RecoverAddressFromTypedDataV4<T, TDomain>(T data, TypedData<TDomain> typedData, string signature)

--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -395,6 +395,11 @@ namespace Thirdweb
             return _personalAccount.EthSign(message);
         }
 
+        public Task<string> RecoverAddressFromEthSign(string message, string signature)
+        {
+            return _personalAccount.RecoverAddressFromEthSign(message, signature);
+        }
+
         public Task<string> PersonalSign(byte[] rawMessage)
         {
             return _personalAccount.PersonalSign(rawMessage);
@@ -440,6 +445,18 @@ namespace Thirdweb
             else
             {
                 throw new Exception("Smart account could not be deployed, unable to sign message.");
+            }
+        }
+
+        public async Task<string> RecoverAddressFromPersonalSign(string message, string signature)
+        {
+            if (!await IsValidSignature(message, signature))
+            {
+                return await _personalAccount.RecoverAddressFromPersonalSign(message, signature);
+            }
+            else
+            {
+                return await GetAddress();
             }
         }
 
@@ -572,6 +589,12 @@ namespace Thirdweb
             where TDomain : IDomain
         {
             return _personalAccount.SignTypedDataV4(data, typedData);
+        }
+
+        public Task<string> RecoverAddressFromTypedDataV4<T, TDomain>(T data, TypedData<TDomain> typedData, string signature)
+            where TDomain : IDomain
+        {
+            return _personalAccount.RecoverAddressFromTypedDataV4(data, typedData, signature);
         }
 
         public async Task<BigInteger> EstimateUserOperationGas(ThirdwebTransactionInput transaction, BigInteger chainId)


### PR DESCRIPTION
With SmartWallet IsValidSignature for PersonalSign(string)

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance address recovery methods in `SmartWallet` and `IThirdwebWallet` interfaces. 

### Detailed summary
- Added `RecoverAddressFromPersonalSign` method to `SmartWallet`
- Added `RecoverAddressFromEthSign` method to `IThirdwebWallet`
- Implemented address recovery logic in `PrivateKeyWallet` and `IThirdwebWallet`
- Added tests for address recovery methods with valid and invalid signatures

> The following files were skipped due to too many changes: `Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.Wallets.Tests.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->