### PR TITLE
Unified Identity - Account Linking

### DIFF
--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -41,8 +41,9 @@ if (!await inAppWalletMain.IsConnected())
         new InAppWalletBrowser()
     );
 }
+Console.WriteLine($"Main InAppWallet address: {await inAppWalletMain.GetAddress()}");
 
-var inAppWalletToLink = await InAppWallet.Create(client: client, email: "firekeeper+tolink@thirdweb.com", authProvider: AuthProvider.Default);
+var inAppWalletToLink = await InAppWallet.Create(client: client, email: "firekeeper+tolink2@thirdweb.com", authProvider: AuthProvider.Default);
 if (await inAppWalletToLink.IsConnected())
 {
     await inAppWalletToLink.Disconnect();
@@ -53,6 +54,11 @@ var otp = Console.ReadLine();
 
 var linkedAccounts = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, otp: otp);
 Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
+
+var linkedAccountsMain = await inAppWalletMain.GetLinkedAccounts();
+Console.WriteLine($"Main linked accounts: {JsonConvert.SerializeObject(linkedAccountsMain, Formatting.Indented)}");
+
+
 
 
 // var erc20SmartWalletSepolia = await SmartWallet.Create(

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -48,46 +48,46 @@ if (!await inAppWalletMain.IsConnected())
 }
 Console.WriteLine($"Main InAppWallet address: {await inAppWalletMain.GetAddress()}");
 
-var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Siwe, siweSigner: privateKeyWallet);
-_ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, chainId: 421614);
+// var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Siwe, siweSigner: privateKeyWallet);
+// _ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, chainId: 421614);
 
-var linkedAccounts = await inAppWalletMain.GetLinkedAccounts();
-Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
+// var linkedAccounts = await inAppWalletMain.GetLinkedAccounts();
+// Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
 
 #endregion
 
 #region ERC20 Smart Wallet - Sepolia
 
-var erc20SmartWalletSepolia = await SmartWallet.Create(
-    personalWallet: privateKeyWallet,
-    chainId: 11155111, // sepolia
-    gasless: true,
-    erc20PaymasterAddress: "0xEc87d96E3F324Dcc828750b52994C6DC69C8162b", // deposit paymaster
-    erc20PaymasterToken: "0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8" // usdc
-);
-var erc20SmartWalletSepoliaAddress = await erc20SmartWalletSepolia.GetAddress();
-Console.WriteLine($"ERC20 Smart Wallet Sepolia address: {erc20SmartWalletSepoliaAddress}");
+// var erc20SmartWalletSepolia = await SmartWallet.Create(
+//     personalWallet: privateKeyWallet,
+//     chainId: 11155111, // sepolia
+//     gasless: true,
+//     erc20PaymasterAddress: "0xEc87d96E3F324Dcc828750b52994C6DC69C8162b", // deposit paymaster
+//     erc20PaymasterToken: "0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8" // usdc
+// );
+// var erc20SmartWalletSepoliaAddress = await erc20SmartWalletSepolia.GetAddress();
+// Console.WriteLine($"ERC20 Smart Wallet Sepolia address: {erc20SmartWalletSepoliaAddress}");
 
-var selfTransfer = await ThirdwebTransaction.Create(
-    wallet: erc20SmartWalletSepolia,
-    txInput: new ThirdwebTransactionInput() { From = erc20SmartWalletSepoliaAddress, To = erc20SmartWalletSepoliaAddress, },
-    chainId: 11155111
-);
+// var selfTransfer = await ThirdwebTransaction.Create(
+//     wallet: erc20SmartWalletSepolia,
+//     txInput: new ThirdwebTransactionInput() { From = erc20SmartWalletSepoliaAddress, To = erc20SmartWalletSepoliaAddress, },
+//     chainId: 11155111
+// );
 
-var estimateGas = await ThirdwebTransaction.EstimateGasCosts(selfTransfer);
-Console.WriteLine($"Self transfer gas estimate: {estimateGas.ether}");
-Console.WriteLine("Make sure you have enough USDC!");
-Console.ReadLine();
+// var estimateGas = await ThirdwebTransaction.EstimateGasCosts(selfTransfer);
+// Console.WriteLine($"Self transfer gas estimate: {estimateGas.ether}");
+// Console.WriteLine("Make sure you have enough USDC!");
+// Console.ReadLine();
 
-var receipt = await ThirdwebTransaction.SendAndWaitForTransactionReceipt(selfTransfer);
-Console.WriteLine($"Self transfer receipt: {JsonConvert.SerializeObject(receipt, Formatting.Indented)}");
+// var receipt = await ThirdwebTransaction.SendAndWaitForTransactionReceipt(selfTransfer);
+// Console.WriteLine($"Self transfer receipt: {JsonConvert.SerializeObject(receipt, Formatting.Indented)}");
 
 #endregion
 
 #region Chain Data Fetching
 
-var chainData = await Utils.FetchThirdwebChainDataAsync(client, 421614);
-Console.WriteLine($"Chain data: {JsonConvert.SerializeObject(chainData, Formatting.Indented)}");
+// var chainData = await Utils.FetchThirdwebChainDataAsync(client, 421614);
+// Console.WriteLine($"Chain data: {JsonConvert.SerializeObject(chainData, Formatting.Indented)}");
 
 #endregion
 

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -48,11 +48,14 @@ if (!await inAppWalletMain.IsConnected())
 }
 Console.WriteLine($"Main InAppWallet address: {await inAppWalletMain.GetAddress()}");
 
-// var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Siwe, siweSigner: privateKeyWallet);
-// _ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, chainId: 421614);
+// var inAppWalletToLink = await InAppWallet.Create(client: client, email: "firekeeper+toLink3@thirdweb.com");
+// _ = inAppWalletToLink.SendOTP();
+// Console.WriteLine("Enter OTP:");
+// var otp = Console.ReadLine();
+// _ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, otp: otp);
 
-// var linkedAccounts = await inAppWalletMain.GetLinkedAccounts();
-// Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
+var linkedAccounts = await inAppWalletMain.GetLinkedAccounts();
+Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts)}");
 
 #endregion
 

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -17,15 +17,20 @@ var privateKey = Environment.GetEnvironmentVariable("PRIVATE_KEY");
 // Fetch timeout options are optional, default is 60000ms
 var client = ThirdwebClient.Create(secretKey: secretKey, fetchTimeoutOptions: new TimeoutOptions(storage: 30000, rpc: 60000));
 
+// Create a private key wallet
+var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
+var walletAddress = await privateKeyWallet.GetAddress();
+Console.WriteLine($"PK Wallet address: {walletAddress}");
+
+#region Contract Interaction
+
 var contract = await ThirdwebContract.Create(client: client, address: "0x81ebd23aA79bCcF5AaFb9c9c5B0Db4223c39102e", chain: 421614);
 var readResult = await contract.Read<string>("name");
 Console.WriteLine($"Contract read result: {readResult}");
 
-// Create wallets (this is an advanced use case, typically one wallet is plenty)
-// var privateKeyWallet = await PrivateKeyWallet.Create(client: client, privateKeyHex: privateKey);
-var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
-var walletAddress = await privateKeyWallet.GetAddress();
-Console.WriteLine($"PK Wallet address: {walletAddress}");
+#endregion
+
+#region Account Linking
 
 var inAppWalletMain = await InAppWallet.Create(client: client, authProvider: AuthProvider.Google);
 if (!await inAppWalletMain.IsConnected())
@@ -43,53 +48,51 @@ if (!await inAppWalletMain.IsConnected())
 }
 Console.WriteLine($"Main InAppWallet address: {await inAppWalletMain.GetAddress()}");
 
-var inAppWalletToLink = await InAppWallet.Create(client: client, email: "firekeeper+tolink2@thirdweb.com", authProvider: AuthProvider.Default);
-if (await inAppWalletToLink.IsConnected())
-{
-    await inAppWalletToLink.Disconnect();
-}
-await inAppWalletToLink.SendOTP();
-Console.WriteLine("Please submit the OTP.");
-var otp = Console.ReadLine();
+var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Siwe, siweSigner: privateKeyWallet);
+_ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, chainId: 421614);
 
-var linkedAccounts = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, otp: otp);
+var linkedAccounts = await inAppWalletMain.GetLinkedAccounts();
 Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
 
-var linkedAccountsMain = await inAppWalletMain.GetLinkedAccounts();
-Console.WriteLine($"Main linked accounts: {JsonConvert.SerializeObject(linkedAccountsMain, Formatting.Indented)}");
+#endregion
 
+#region ERC20 Smart Wallet - Sepolia
 
+var erc20SmartWalletSepolia = await SmartWallet.Create(
+    personalWallet: privateKeyWallet,
+    chainId: 11155111, // sepolia
+    gasless: true,
+    erc20PaymasterAddress: "0xEc87d96E3F324Dcc828750b52994C6DC69C8162b", // deposit paymaster
+    erc20PaymasterToken: "0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8" // usdc
+);
+var erc20SmartWalletSepoliaAddress = await erc20SmartWalletSepolia.GetAddress();
+Console.WriteLine($"ERC20 Smart Wallet Sepolia address: {erc20SmartWalletSepoliaAddress}");
 
+var selfTransfer = await ThirdwebTransaction.Create(
+    wallet: erc20SmartWalletSepolia,
+    txInput: new ThirdwebTransactionInput() { From = erc20SmartWalletSepoliaAddress, To = erc20SmartWalletSepoliaAddress, },
+    chainId: 11155111
+);
 
-// var erc20SmartWalletSepolia = await SmartWallet.Create(
-//     personalWallet: privateKeyWallet,
-//     chainId: 11155111, // sepolia
-//     gasless: true,
-//     erc20PaymasterAddress: "0xEc87d96E3F324Dcc828750b52994C6DC69C8162b", // deposit paymaster
-//     erc20PaymasterToken: "0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8" // usdc
-// );
-// var erc20SmartWalletSepoliaAddress = await erc20SmartWalletSepolia.GetAddress();
-// Console.WriteLine($"ERC20 Smart Wallet Sepolia address: {erc20SmartWalletSepoliaAddress}");
+var estimateGas = await ThirdwebTransaction.EstimateGasCosts(selfTransfer);
+Console.WriteLine($"Self transfer gas estimate: {estimateGas.ether}");
+Console.WriteLine("Make sure you have enough USDC!");
+Console.ReadLine();
 
-// var selfTransfer = await ThirdwebTransaction.Create(
-//     wallet: erc20SmartWalletSepolia,
-//     txInput: new ThirdwebTransactionInput() { From = erc20SmartWalletSepoliaAddress, To = erc20SmartWalletSepoliaAddress, },
-//     chainId: 11155111
-// );
+var receipt = await ThirdwebTransaction.SendAndWaitForTransactionReceipt(selfTransfer);
+Console.WriteLine($"Self transfer receipt: {JsonConvert.SerializeObject(receipt, Formatting.Indented)}");
 
-// var estimateGas = await ThirdwebTransaction.EstimateGasCosts(selfTransfer);
-// Console.WriteLine($"Self transfer gas estimate: {estimateGas.ether}");
-// Console.WriteLine("Make sure you have enough USDC!");
-// Console.ReadLine();
+#endregion
 
-// var receipt = await ThirdwebTransaction.SendAndWaitForTransactionReceipt(selfTransfer);
-// Console.WriteLine($"Self transfer receipt: {JsonConvert.SerializeObject(receipt, Formatting.Indented)}");
+#region Chain Data Fetching
 
-// // var chainData = await Utils.FetchThirdwebChainDataAsync(client, 421614);
-// // Console.WriteLine($"Chain data: {JsonConvert.SerializeObject(chainData, Formatting.Indented)}");
-// Console.WriteLine($"Wallet address: {walletAddress}");
+var chainData = await Utils.FetchThirdwebChainDataAsync(client, 421614);
+Console.WriteLine($"Chain data: {JsonConvert.SerializeObject(chainData, Formatting.Indented)}");
 
-// // Self transfer 0 on chain 842
+#endregion
+
+#region Self Transfer Transaction
+
 // var tx = await ThirdwebTransaction.Create(
 //     wallet: privateKeyWallet,
 //     txInput: new ThirdwebTransactionInput()
@@ -103,8 +106,9 @@ Console.WriteLine($"Main linked accounts: {JsonConvert.SerializeObject(linkedAcc
 // var txHash = await ThirdwebTransaction.Send(tx);
 // Console.WriteLine($"Transaction hash: {txHash}");
 
-// var chainData = await Utils.FetchThirdwebChainDataAsync(client, 421614);
-// Console.WriteLine($"Chain data: {JsonConvert.SerializeObject(chainData, Formatting.Indented)}");
+#endregion
+
+#region InAppWallet - OAuth
 
 // var inAppWalletOAuth = await InAppWallet.Create(client: client, authProvider: AuthProvider.Telegram);
 // if (!await inAppWalletOAuth.IsConnected())
@@ -123,10 +127,14 @@ Console.WriteLine($"Main linked accounts: {JsonConvert.SerializeObject(linkedAcc
 // var inAppWalletOAuthAddress = await inAppWalletOAuth.GetAddress();
 // Console.WriteLine($"InAppWallet OAuth address: {inAppWalletOAuthAddress}");
 
+#endregion
+
+#region Smart Wallet - Gasless Transaction
+
 // var smartWallet = await SmartWallet.Create(privateKeyWallet, 78600);
 
-// // self transfer 0
-// var tx = await ThirdwebTransaction.Create(
+// // Self transfer 0
+// var tx2 = await ThirdwebTransaction.Create(
 //     smartWallet,
 //     new ThirdwebTransactionInput()
 //     {
@@ -136,22 +144,19 @@ Console.WriteLine($"Main linked accounts: {JsonConvert.SerializeObject(linkedAcc
 //     },
 //     78600
 // );
-// var txHash = await ThirdwebTransaction.Send(tx);
-// Console.WriteLine($"Transaction hash: {txHash}");
+// var txHash2 = await ThirdwebTransaction.Send(tx2);
+// Console.WriteLine($"Transaction hash: {txHash2}");
 
-// // Buy with Fiat
-// // Find out more about supported FIAT currencies
+#endregion
+
+#region Buy with Fiat
+
+// // Supported currencies
 // var supportedCurrencies = await ThirdwebPay.GetBuyWithFiatCurrencies(client);
 // Console.WriteLine($"Supported currencies: {JsonConvert.SerializeObject(supportedCurrencies, Formatting.Indented)}");
 
 // // Get a Buy with Fiat quote
-// var fiatQuoteParams = new BuyWithFiatQuoteParams(
-//     fromCurrencySymbol: "USD",
-//     toAddress: walletAddress,
-//     toChainId: "137",
-//     toTokenAddress: Thirdweb.Constants.NATIVE_TOKEN_ADDRESS,
-//     toAmount: "20"
-// );
+// var fiatQuoteParams = new BuyWithFiatQuoteParams(fromCurrencySymbol: "USD", toAddress: walletAddress, toChainId: "137", toTokenAddress: Thirdweb.Constants.NATIVE_TOKEN_ADDRESS, toAmount: "20");
 // var fiatOnrampQuote = await ThirdwebPay.GetBuyWithFiatQuote(client, fiatQuoteParams);
 // Console.WriteLine($"Fiat onramp quote: {JsonConvert.SerializeObject(fiatOnrampQuote, Formatting.Indented)}");
 
@@ -173,9 +178,11 @@ Console.WriteLine($"Main linked accounts: {JsonConvert.SerializeObject(linkedAcc
 //     await Task.Delay(5000);
 // }
 
-// Buy with Crypto
+#endregion
 
-// Swap Polygon MATIC to Base ETH
+#region Buy with Crypto
+
+// // Swap Polygon MATIC to Base ETH
 // var swapQuoteParams = new BuyWithCryptoQuoteParams(
 //     fromAddress: walletAddress,
 //     fromChainId: 137,
@@ -188,184 +195,22 @@ Console.WriteLine($"Main linked accounts: {JsonConvert.SerializeObject(linkedAcc
 // Console.WriteLine($"Swap quote: {JsonConvert.SerializeObject(swapQuote, Formatting.Indented)}");
 
 // // Initiate swap
-// var txHash = await ThirdwebPay.BuyWithCrypto(wallet: privateKeyWallet, buyWithCryptoQuote: swapQuote);
-// Console.WriteLine($"Swap transaction hash: {txHash}");
+// var txHash3 = await ThirdwebPay.BuyWithCrypto(wallet: privateKeyWallet, buyWithCryptoQuote: swapQuote);
+// Console.WriteLine($"Swap transaction hash: {txHash3}");
 
 // // Poll for status
 // var currentSwapStatus = SwapStatus.NONE;
 // while (currentSwapStatus is not SwapStatus.COMPLETED and not SwapStatus.FAILED)
 // {
-//     var swapStatus = await ThirdwebPay.GetBuyWithCryptoStatus(client, txHash);
+//     var swapStatus = await ThirdwebPay.GetBuyWithCryptoStatus(client, txHash3);
 //     currentSwapStatus = Enum.Parse<SwapStatus>(swapStatus.Status);
 //     Console.WriteLine($"Swap status: {JsonConvert.SerializeObject(swapStatus, Formatting.Indented)}");
 //     await Task.Delay(5000);
 // }
 
+#endregion
 
-// var inAppWallet = await InAppWallet.Create(client: client, email: "firekeeper+otpv2@thirdweb.com"); // or email: null, phoneNumber: "+1234567890"
-
-// var inAppWallet = await InAppWallet.Create(client: client, authprovider: AuthProvider.Google); // or email: null, phoneNumber: "+1234567890"
-
-// // Reset InAppWallet (optional step for testing login flow)
-// if (await inAppWallet.IsConnected())
-// {
-//     await inAppWallet.Disconnect();
-// }
-
-// // Relog if InAppWallet not logged in
-// if (!await inAppWallet.IsConnected())
-// {
-//     var address = await inAppWallet.LoginWithOauth(
-//         isMobile: false,
-//         (url) =>
-//         {
-//             var psi = new ProcessStartInfo { FileName = url, UseShellExecute = true };
-//             _ = Process.Start(psi);
-//         },
-//         "thirdweb://",
-//         new InAppWalletBrowser()
-//     );
-//     Console.WriteLine($"InAppWallet address: {address}");
-// }
-
-// if (await inAppWallet.IsConnected())
-// {
-//     Console.WriteLine($"InAppWallet address: {await inAppWallet.GetAddress()}");
-//     return;
-// }
-// await inAppWallet.SendOTP();
-// Console.WriteLine("Please submit the OTP.");
-// retry:
-// var otp = Console.ReadLine();
-// (var inAppWalletAddress, var canRetry) = await inAppWallet.SubmitOTP(otp);
-// if (inAppWalletAddress == null && canRetry)
-// {
-//     Console.WriteLine("Please submit the OTP again.");
-//     goto retry;
-// }
-// if (inAppWalletAddress == null)
-// {
-//     Console.WriteLine("OTP login failed. Please try again.");
-//     return;
-// }
-// Console.WriteLine($"InAppWallet address: {inAppWalletAddress}");
-// }
-
-// Prepare a transaction directly, or with Contract.Prepare
-// var tx = await ThirdwebTransaction.Create(
-//     client: client,
-//     wallet: privateKeyWallet,
-//     txInput: new ThirdwebTransactionInput()
-//     {
-//         From = await privateKeyWallet.GetAddress(),
-//         To = await privateKeyWallet.GetAddress(),
-//         Value = new HexBigInteger(BigInteger.Zero),
-//     },
-//     chainId: 300
-// );
-
-// // Set zkSync options
-// tx.SetZkSyncOptions(
-//     new ZkSyncOptions(
-//         // Paymaster contract address
-//         paymaster: "0xbA226d47Cbb2731CBAA67C916c57d68484AA269F",
-//         // IPaymasterFlow interface encoded data
-//         paymasterInput: "0x8c5a344500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"
-//     )
-// );
-
-// // Send as usual, it's now gasless!
-// var txHash = await ThirdwebTransaction.Send(transaction: tx);
-// Console.WriteLine($"Transaction hash: {txHash}");
-
-// var zkSmartWallet = await SmartWallet.Create(client: client, personalWallet: privateKeyWallet, chainId: 302, gasless: true);
-// Console.WriteLine($"Smart wallet address: {await zkSmartWallet.GetAddress()}");
-// var zkAaTx = await ThirdwebTransaction.Create(client, zkSmartWallet, new ThirdwebTransactionInput() { From = await zkSmartWallet.GetAddress(), To = await zkSmartWallet.GetAddress(), }, 302);
-// var zkSyncSignatureBasedAaTxHash = await ThirdwebTransaction.Send(zkAaTx);
-// Console.WriteLine($"Transaction hash: {zkSyncSignatureBasedAaTxHash}");
-
-// Create smart wallet with InAppWallet signer
-// var smartWallet = await SmartWallet.Create(client: client, personalWallet: inAppWallet, factoryAddress: "0xbf1C9aA4B1A085f7DA890a44E82B0A1289A40052", gasless: true, chainId: 421614);
-// var res = await smartWallet.Authenticate("http://localhost:8000", 421614);
-// Console.WriteLine($"Smart wallet auth result: {res}");
-
-// // Grant a session key to pk wallet (advanced use case)
-// _ = await smartWallet.CreateSessionKey(
-//     signerAddress: await privateKeyWallet.GetAddress(),
-//     approvedTargets: new List<string>() { Constants.ADDRESS_ZERO },
-//     nativeTokenLimitPerTransactionInWei: "0",
-//     permissionStartTimestamp: "0",
-//     permissionEndTimestamp: (Utils.GetUnixTimeStampNow() + 86400).ToString(),
-//     reqValidityStartTimestamp: "0",
-//     reqValidityEndTimestamp: Utils.GetUnixTimeStampIn10Years().ToString()
-// );
-
-// // Reconnect to same smart wallet with pk wallet as signer (specifying wallet address override)
-// smartWallet = await SmartWallet.Create(
-//     client: client,
-//     personalWallet: privateKeyWallet,
-//     factoryAddress: "0xbf1C9aA4B1A085f7DA890a44E82B0A1289A40052",
-//     gasless: true,
-//     chainId: 421614,
-//     accountAddressOverride: await smartWallet.GetAddress()
-// );
-
-// // Log addresses
-// Console.WriteLine($"PrivateKey Wallet: {await privateKeyWallet.GetAddress()}");
-// Console.WriteLine($"InAppWallet: {await inAppWallet.GetAddress()}");
-// Console.WriteLine($"Smart Wallet: {await smartWallet.GetAddress()}");
-
-// // Sign, triggering deploy as needed and 1271 verification if it's a smart wallet
-// var message = "Hello, Thirdweb!";
-// var signature = await smartWallet.PersonalSign(message);
-// Console.WriteLine($"Signed message: {signature}");
-
-// var balanceBefore = await ThirdwebContract.Read<BigInteger>(contract, "balanceOf", await smartWallet.GetAddress());
-// Console.WriteLine($"Balance before mint: {balanceBefore}");
-
-// var writeResult = await ThirdwebContract.Write(smartWallet, contract, "mintTo", 0, await smartWallet.GetAddress(), 100);
-// Console.WriteLine($"Contract write result: {writeResult}");
-
-// var balanceAfter = await ThirdwebContract.Read<BigInteger>(contract, "balanceOf", await smartWallet.GetAddress());
-// Console.WriteLine($"Balance after mint: {balanceAfter}");
-
-// // Transaction Builder
-// var preparedTx = await ThirdwebContract.Prepare(wallet: smartWallet, contract: contract, method: "mintTo", weiValue: 0, parameters: new object[] { await smartWallet.GetAddress(), 100 });
-// Console.WriteLine($"Prepared transaction: {preparedTx}");
-// var estimatedCosts = await ThirdwebTransaction.EstimateGasCosts(preparedTx);
-// Console.WriteLine($"Estimated ETH gas cost: {estimatedCosts.ether}");
-// var totalCosts = await ThirdwebTransaction.EstimateTotalCosts(preparedTx);
-// Console.WriteLine($"Estimated ETH total cost: {totalCosts.ether}");
-// var simulationData = await ThirdwebTransaction.Simulate(preparedTx);
-// Console.WriteLine($"Simulation data: {simulationData}");
-// var txHash = await ThirdwebTransaction.Send(preparedTx);
-// Console.WriteLine($"Transaction hash: {txHash}");
-// var receipt = await ThirdwebTransaction.WaitForTransactionReceipt(client, 421614, txHash);
-// Console.WriteLine($"Transaction receipt: {JsonConvert.SerializeObject(receipt)}");
-
-// // Transaction Builder - raw transfer
-// var rawTx = new ThirdwebTransactionInput
-// {
-//     From = await smartWallet.GetAddress(),
-//     To = await smartWallet.GetAddress(),
-//     Value = new HexBigInteger(BigInteger.Zero),
-//     Data = "0x",
-// };
-// var preparedRawTx = await ThirdwebTransaction.Create(client: client, wallet: smartWallet, txInput: rawTx, chainId: 421614);
-// Console.WriteLine($"Prepared raw transaction: {preparedRawTx}");
-// var estimatedCostsRaw = await ThirdwebTransaction.EstimateGasCosts(preparedRawTx);
-// Console.WriteLine($"Estimated ETH gas cost: {estimatedCostsRaw.ether}");
-// var totalCostsRaw = await ThirdwebTransaction.EstimateTotalCosts(preparedRawTx);
-// Console.WriteLine($"Estimated ETH total cost: {totalCostsRaw.ether}");
-// var simulationDataRaw = await ThirdwebTransaction.Simulate(preparedRawTx);
-// Console.WriteLine($"Simulation data: {simulationDataRaw}");
-// var txHashRaw = await ThirdwebTransaction.Send(preparedRawTx);
-// Console.WriteLine($"Raw transaction hash: {txHashRaw}");
-// var receiptRaw = await ThirdwebTransaction.WaitForTransactionReceipt(client, 421614, txHashRaw);
-// Console.WriteLine($"Raw transaction receipt: {JsonConvert.SerializeObject(receiptRaw)}");
-
-
-// Storage actions
+#region Storage Actions
 
 // // Will download from IPFS or normal urls
 // var downloadResult = await ThirdwebStorage.Download<string>(client: client, uri: "AnyUrlIncludingIpfs");
@@ -375,9 +220,13 @@ Console.WriteLine($"Main linked accounts: {JsonConvert.SerializeObject(linkedAcc
 // var uploadResult = await ThirdwebStorage.Upload(client: client, path: "AnyPath");
 // Console.WriteLine($"Upload result preview: {uploadResult.PreviewUrl}");
 
+#endregion
 
-// Access RPC directly if needed, generally not recommended
+#region RPC Access
 
+// // Access RPC directly if needed, generally not recommended
 // var rpc = ThirdwebRPC.GetRpcInstance(client, 421614);
 // var blockNumber = await rpc.SendRequestAsync<string>("eth_blockNumber");
 // Console.WriteLine($"Block number: {blockNumber}");
+
+#endregion

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet.Authentication/Server.Types.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet.Authentication/Server.Types.cs
@@ -25,6 +25,39 @@ namespace Thirdweb.EWS
         }
 
         [DataContract]
+        internal class AccountConnectResponse
+        {
+            [DataMember(Name = "linkedAccounts", IsRequired = true)]
+            public List<LinkedAccount> LinkedAccounts { get; set; }
+        }
+
+        [DataContract]
+        public class LinkedAccount
+        {
+            [DataMember(Name = "type", IsRequired = true)]
+            public string Type { get; set; }
+
+            [DataMember(Name = "details", IsRequired = true)]
+            public LinkedAccountDetails Details { get; set; }
+
+            [DataContract]
+            public class LinkedAccountDetails
+            {
+                [DataMember(Name = "email", EmitDefaultValue = false)]
+                public string Email { get; set; }
+
+                [DataMember(Name = "address", EmitDefaultValue = false)]
+                public string Address { get; set; }
+
+                [DataMember(Name = "phone", EmitDefaultValue = false)]
+                public string Phone { get; set; }
+
+                [DataMember(Name = "id", EmitDefaultValue = false)]
+                public string Id { get; set; }
+            }
+        }
+
+        [DataContract]
         private class SendEmailOtpReturnType
         {
             [DataMember(Name = "email")]

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet.Storage/LocalStorage.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet.Storage/LocalStorage.cs
@@ -20,7 +20,7 @@ namespace Thirdweb.EWS
         {
             string directory;
             directory = storageDirectoryPath ?? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            directory = Path.Combine(directory, "EWS");
+            directory = Path.Combine(directory, "Thirdweb", "InAppWallet");
             _ = Directory.CreateDirectory(directory);
             filePath = Path.Combine(directory, $"{clientId}.txt");
             try

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.AccountLinking.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.AccountLinking.cs
@@ -6,5 +6,10 @@ namespace Thirdweb.EWS
         {
             return await server.LinkAccountAsync(currentAccountToken, authTokenToConnect).ConfigureAwait(false);
         }
+
+        public async Task<List<Server.LinkedAccount>> GetLinkedAccountsAsync(string currentAccountToken)
+        {
+            return await server.GetLinkedAccountsAsync(currentAccountToken).ConfigureAwait(false);
+        }
     }
 }

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.AccountLinking.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.AccountLinking.cs
@@ -1,0 +1,10 @@
+namespace Thirdweb.EWS
+{
+    internal partial class EmbeddedWallet
+    {
+        public async Task<List<Server.LinkedAccount>> LinkAccountAsync(string currentAccountToken, string authTokenToConnect)
+        {
+            return await server.LinkAccountAsync(currentAccountToken, authTokenToConnect).ConfigureAwait(false);
+        }
+    }
+}

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.AuthEndpoint.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.AuthEndpoint.cs
@@ -2,10 +2,9 @@ namespace Thirdweb.EWS
 {
     internal partial class EmbeddedWallet
     {
-        public async Task<VerifyResult> SignInWithAuthEndpointAsync(string payload, string encryptionKey)
+        public async Task<Server.VerifyResult> SignInWithAuthEndpointAsync(string payload)
         {
-            var result = await server.VerifyAuthEndpointAsync(payload).ConfigureAwait(false);
-            return await PostAuthSetup(result, encryptionKey, "AuthEndpoint").ConfigureAwait(false);
+            return await server.VerifyAuthEndpointAsync(payload).ConfigureAwait(false);
         }
     }
 }

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.EmailOTP.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.EmailOTP.cs
@@ -11,18 +11,10 @@ namespace Thirdweb.EWS
             return (userWallet.IsNewUser, isNewDevice);
         }
 
-        public async Task<VerifyResult> VerifyEmailOtpAsync(string emailAddress, string otp)
+        public async Task<Server.VerifyResult> VerifyEmailOtpAsync(string emailAddress, string otp)
         {
             emailAddress = emailAddress.ToLower();
-            try
-            {
-                var result = await server.VerifyEmailOtpAsync(emailAddress, otp).ConfigureAwait(false);
-                return await PostAuthSetup(result, null, "Email").ConfigureAwait(false);
-            }
-            catch (VerificationException ex)
-            {
-                return new VerifyResult(ex.CanRetry);
-            }
+            return await server.VerifyEmailOtpAsync(emailAddress, otp).ConfigureAwait(false);
         }
     }
 }

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.JWT.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.JWT.cs
@@ -2,10 +2,9 @@ namespace Thirdweb.EWS
 {
     internal partial class EmbeddedWallet
     {
-        public async Task<VerifyResult> SignInWithJwtAsync(string jwt, string encryptionKey)
+        public async Task<Server.VerifyResult> SignInWithJwtAsync(string jwt)
         {
-            var result = await server.VerifyJwtAsync(jwt).ConfigureAwait(false);
-            return await PostAuthSetup(result, encryptionKey, "JWT").ConfigureAwait(false);
+            return await server.VerifyJwtAsync(jwt).ConfigureAwait(false);
         }
     }
 }

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.Misc.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.Misc.cs
@@ -13,7 +13,12 @@ namespace Thirdweb.EWS
             }
         }
 
-        private async Task<VerifyResult> PostAuthSetup(Server.VerifyResult result, string twManagedRecoveryCodeOverride, string authProvider)
+        internal string GetCurrentAuthToken()
+        {
+            return localStorage.Data?.AuthToken;
+        }
+
+        internal async Task<VerifyResult> PostAuthSetup(Server.VerifyResult result, string twManagedRecoveryCodeOverride, string authProvider)
         {
             var walletUserId = result.WalletUserId;
             var authToken = result.AuthToken;

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.Misc.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.Misc.cs
@@ -48,15 +48,12 @@ namespace Thirdweb.EWS
             switch (userWallet.Status)
             {
                 case "Logged Out":
-                    await SignOutAsync().ConfigureAwait(false);
                     throw new InvalidOperationException("User is logged out");
                 case "Logged In, Wallet Uninitialized":
-                    await SignOutAsync().ConfigureAwait(false);
                     throw new InvalidOperationException("User is logged in but wallet is uninitialized");
                 case "Logged In, Wallet Initialized":
                     if (string.IsNullOrEmpty(localStorage.Data?.DeviceShare))
                     {
-                        await SignOutAsync().ConfigureAwait(false);
                         throw new InvalidOperationException("User is logged in but wallet is uninitialized");
                     }
 
@@ -66,12 +63,10 @@ namespace Thirdweb.EWS
 
                     if ((email != null && email != emailAddress) || (phone != null && phone != phoneNumber))
                     {
-                        await SignOutAsync().ConfigureAwait(false);
                         throw new InvalidOperationException("User email or phone number do not match");
                     }
                     else if (email == null && localStorage.Data.AuthProvider != authProvider)
                     {
-                        await SignOutAsync().ConfigureAwait(false);
                         throw new InvalidOperationException($"User auth provider does not match. Expected {localStorage.Data.AuthProvider}, got {authProvider}");
                     }
                     else if (authShare == null)

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.Misc.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.Misc.cs
@@ -4,15 +4,6 @@ namespace Thirdweb.EWS
 {
     internal partial class EmbeddedWallet
     {
-        public async Task VerifyThirdwebClientIdAsync(string domain)
-        {
-            var error = await server.VerifyThirdwebClientIdAsync(domain).ConfigureAwait(false);
-            if (error != "")
-            {
-                throw new InvalidOperationException($"Invalid thirdweb client id for domain {domain} | {error}");
-            }
-        }
-
         internal string GetCurrentAuthToken()
         {
             return localStorage.Data?.AuthToken;

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.OAuth.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.OAuth.cs
@@ -4,10 +4,9 @@ namespace Thirdweb.EWS
 {
     internal partial class EmbeddedWallet
     {
-        public async Task<VerifyResult> SignInWithOauthAsync(string authProvider, string authResult)
+        public async Task<Server.VerifyResult> SignInWithOauthAsync(string authProvider, string authResult)
         {
-            var result = await server.VerifyOAuthAsync(authResult).ConfigureAwait(false);
-            return await PostAuthSetup(result, null, authProvider).ConfigureAwait(false);
+            return await server.VerifyOAuthAsync(authResult).ConfigureAwait(false);
         }
 
         public async Task<string> FetchHeadlessOauthLoginLinkAsync(string authProvider, string platform)

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.PhoneOTP.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.PhoneOTP.cs
@@ -10,17 +10,9 @@ namespace Thirdweb.EWS
             return (userWallet.IsNewUser, isNewDevice);
         }
 
-        public async Task<VerifyResult> VerifyPhoneOtpAsync(string phoneNumber, string otp)
+        public async Task<Server.VerifyResult> VerifyPhoneOtpAsync(string phoneNumber, string otp)
         {
-            try
-            {
-                var result = await server.VerifyPhoneOtpAsync(phoneNumber, otp).ConfigureAwait(false);
-                return await PostAuthSetup(result, null, "Phone").ConfigureAwait(false);
-            }
-            catch (VerificationException ex)
-            {
-                return new VerifyResult(ex.CanRetry);
-            }
+            return await server.VerifyPhoneOtpAsync(phoneNumber, otp).ConfigureAwait(false);
         }
     }
 }

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.SIWE.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.SIWE.cs
@@ -4,15 +4,14 @@ namespace Thirdweb.EWS
 {
     internal partial class EmbeddedWallet
     {
-        public async Task<VerifyResult> SignInWithSiweAsync(IThirdwebWallet signer, BigInteger chainId)
+        public async Task<Server.VerifyResult> SignInWithSiweAsync(IThirdwebWallet signer, BigInteger chainId)
         {
             var address = await signer.GetAddress().ConfigureAwait(false);
             var payload = await server.FetchSiwePayloadAsync(address, chainId.ToString()).ConfigureAwait(false);
             var payloadMsg = Utils.GenerateSIWE(payload);
             var signature = await signer.PersonalSign(payloadMsg).ConfigureAwait(false);
 
-            var result = await server.VerifySiweAsync(payload, signature).ConfigureAwait(false);
-            return await PostAuthSetup(result, address, null).ConfigureAwait(false);
+            return await server.VerifySiweAsync(payload, signature).ConfigureAwait(false);
         }
     }
 }

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs
@@ -107,7 +107,6 @@ namespace Thirdweb
             EthECKey ecKey;
             try
             {
-                if (!string.IsNullOrEmpty(authproviderStr)) { }
                 var user = await embeddedWallet.GetUserAsync(email, phoneNumber, authproviderStr);
                 ecKey = new EthECKey(user.Account.PrivateKey);
             }

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs
@@ -172,7 +172,7 @@ namespace Thirdweb
 
             if (await walletToLink.IsConnected())
             {
-                throw new ArgumentException("Cannot link account with a wallet that is already connected. Please call InAppWallet.Disconnect() on the wallet to link before linking.");
+                throw new ArgumentException("Cannot link account with a wallet that is already created and connected.");
             }
 
             Server.VerifyResult serverRes = null;
@@ -209,7 +209,7 @@ namespace Thirdweb
                 case "AuthEndpoint":
                     if (string.IsNullOrEmpty(payload))
                     {
-                        throw new ArgumentException("Cannot link account with an AuthEndpoint wallet without an payload.");
+                        throw new ArgumentException("Cannot link account with an AuthEndpoint wallet without a payload.");
                     }
                     serverRes = await walletToLink.PreAuth_AuthEndpoint(payload).ConfigureAwait(false);
                     break;

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs
@@ -249,6 +249,30 @@ namespace Thirdweb
             return linkedAccounts;
         }
 
+        public async Task<List<LinkedAccount>> GetLinkedAccounts()
+        {
+            var currentAccountToken = _embeddedWallet.GetCurrentAuthToken();
+            var serverLinkedAccounts = await _embeddedWallet.GetLinkedAccountsAsync(currentAccountToken).ConfigureAwait(false);
+            var linkedAccounts = new List<LinkedAccount>();
+            foreach (var linkedAccount in serverLinkedAccounts)
+            {
+                linkedAccounts.Add(
+                    new LinkedAccount
+                    {
+                        Type = linkedAccount.Type,
+                        Details = new LinkedAccount.LinkedAccountDetails
+                        {
+                            Email = linkedAccount.Details?.Email,
+                            Address = linkedAccount.Details?.Address,
+                            Phone = linkedAccount.Details?.Phone,
+                            Id = linkedAccount.Details?.Id
+                        }
+                    }
+                );
+            }
+            return linkedAccounts;
+        }
+
         #endregion
 
         #region OAuth2 Flow
@@ -510,7 +534,7 @@ namespace Thirdweb
 
         private async Task<string> PostAuth(Server.VerifyResult serverRes, string encryptionKey, string authProvider)
         {
-            var res = await _embeddedWallet.PostAuthSetup(serverRes, encryptionKey, "JWT").ConfigureAwait(false);
+            var res = await _embeddedWallet.PostAuthSetup(serverRes, encryptionKey, authProvider).ConfigureAwait(false);
             if (res.User == null)
             {
                 throw new Exception($"Failed to login with {authProvider}");


### PR DESCRIPTION
Separate Pre and Post Auth, allow linking an InAppWallet to another

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on restructuring directory paths, updating authentication methods, and introducing new classes for account linking in the Embedded Wallet module.

### Detailed summary
- Restructured directory paths in `LocalStorage.cs`
- Updated authentication methods in `EmbeddedWallet.JWT.cs`, `EmbeddedWallet.AuthEndpoint.cs`, `EmbeddedWallet.PhoneOTP.cs`, `EmbeddedWallet.EmailOTP.cs`, `EmbeddedWallet.OAuth.cs`, `EmbeddedWallet.SIWE.cs`
- Introduced `Server.VerifyResult` return type in authentication methods
- Added `Thirdweb.EWS` namespace with account linking methods in `EmbeddedWallet.AccountLinking.cs`
- Added `Server.Types.cs` with new data contract classes
- Modified `Server.cs` with account linking and retrieval methods

> The following files were skipped due to too many changes: `Thirdweb.Console/Program.cs`, `Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->