### PR TITLE
Extract func sig from more kinds of inputs

### DIFF
--- a/Thirdweb.Tests/Thirdweb.Contracts/Thirdweb.Contracts.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Contracts/Thirdweb.Contracts.Tests.cs
@@ -78,6 +78,22 @@ public class ContractsTests : BaseTests
         Assert.Equal(0, result.ReturnValue2);
     }
 
+    [Fact(Timeout = 120000)]
+    public async Task ReadTest_FullSig()
+    {
+        var contract = await GetContract();
+        var result = await ThirdwebContract.Read<string>(contract, "function name() view returns (string)");
+        Assert.Equal("Kitty DropERC20", result);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task ReadTest_PartialSig()
+    {
+        var contract = await GetContract();
+        var result = await ThirdwebContract.Read<string>(contract, "name()");
+        Assert.Equal("Kitty DropERC20", result);
+    }
+
     private class AllowlistProof
     {
         public List<byte[]> Proof { get; set; } = new();
@@ -98,6 +114,35 @@ public class ContractsTests : BaseTests
         var allowlistProof = new object[] { new byte[] { }, BigInteger.Zero, BigInteger.Zero, Constants.ADDRESS_ZERO };
         var data = new byte[] { };
         var result = await ThirdwebContract.Write(smartAccount, contract, "claim", 0, receiver, quantity, currency, pricePerToken, allowlistProof, data);
+        Assert.NotNull(result);
+        var receipt = await ThirdwebTransaction.WaitForTransactionReceipt(contract.Client, contract.Chain, result.TransactionHash);
+        Assert.NotNull(receipt);
+        Assert.Equal(result.TransactionHash, receipt.TransactionHash);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task WriteTest_SmartAccount_FullSig()
+    {
+        var contract = await GetContract();
+        var smartAccount = await GetAccount();
+        var receiver = await smartAccount.GetAddress();
+        var quantity = BigInteger.One;
+        var currency = Constants.NATIVE_TOKEN_ADDRESS;
+        var pricePerToken = BigInteger.Zero;
+        var allowlistProof = new object[] { new byte[] { }, BigInteger.Zero, BigInteger.Zero, Constants.ADDRESS_ZERO };
+        var data = new byte[] { };
+        var result = await ThirdwebContract.Write(
+            smartAccount,
+            contract,
+            "claim(address, uint256, address, uint256, (bytes32[], uint256, uint256, address), bytes)",
+            0,
+            receiver,
+            quantity,
+            currency,
+            pricePerToken,
+            allowlistProof,
+            data
+        );
         Assert.NotNull(result);
         var receipt = await ThirdwebTransaction.WaitForTransactionReceipt(contract.Client, contract.Chain, result.TransactionHash);
         Assert.NotNull(receipt);

--- a/Thirdweb/Thirdweb.Contracts/ThirdwebContract.cs
+++ b/Thirdweb/Thirdweb.Contracts/ThirdwebContract.cs
@@ -223,18 +223,18 @@ namespace Thirdweb
                 throw new ArgumentException("Invalid function signature: Missing opening parenthesis.");
             }
 
-            var endOfParameters = method.IndexOf(')', startOfParameters);
+            var endOfParameters = method.LastIndexOf(')');
             if (endOfParameters == -1)
             {
                 throw new ArgumentException("Invalid function signature: Missing closing parenthesis.");
             }
 
-            var canonicalSignature = method.Substring(0, endOfParameters + 1);
-            if (canonicalSignature.Contains(" "))
-            {
-                canonicalSignature = canonicalSignature.Substring(canonicalSignature.LastIndexOf(' ') + 1);
-            }
+            var functionName = method.Substring(0, startOfParameters).Trim().Split(' ').Last(); // Get the last part after any spaces (in case of "function name(...)")
+            var parameters = method.Substring(startOfParameters + 1, endOfParameters - startOfParameters - 1);
 
+            var paramTypes = parameters.Split(',').Select(param => param.Trim().Split(' ')[0]).ToArray();
+
+            var canonicalSignature = $"{functionName}({string.Join(",", paramTypes)})";
             return canonicalSignature;
         }
     }

--- a/Thirdweb/Thirdweb.Contracts/ThirdwebContract.cs
+++ b/Thirdweb/Thirdweb.Contracts/ThirdwebContract.cs
@@ -119,11 +119,6 @@ namespace Thirdweb
                 }
             }
 
-            if (function == null)
-            {
-                throw new ArgumentException($"Function '{method}' not found in the contract ABI.");
-            }
-
             var data = function.GetData(parameters);
             var resultData = await rpc.SendRequestAsync<string>("eth_call", new { to = contract.Address, data = data }, "latest").ConfigureAwait(false);
 
@@ -159,6 +154,7 @@ namespace Thirdweb
                     }
                 }
             }
+
             var data = function.GetData(parameters);
             var transaction = new ThirdwebTransactionInput
             {

--- a/Thirdweb/Thirdweb.Contracts/ThirdwebContract.cs
+++ b/Thirdweb/Thirdweb.Contracts/ThirdwebContract.cs
@@ -217,6 +217,7 @@ namespace Thirdweb
         /// <exception cref="ArgumentException"></exception>
         private static string ExtractCanonicalSignature(string method)
         {
+            method = method.Split("returns")[0];
             var startOfParameters = method.IndexOf('(');
             if (startOfParameters == -1)
             {


### PR DESCRIPTION
Can now call "name" with
"name"
"function name() view returns (string)"
"name() view returns (string)"

or "claim(address, uint256, address, uint256, (bytes32[], uint256, uint256, address), bytes)"
or other variants

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance contract interaction in Thirdweb.Contracts.Tests by adding new test methods and refining contract function handling.

### Detailed summary
- Added new test methods for full and partial function signatures
- Improved handling of contract functions with missing signature matches
- Implemented method to extract canonical function signature from a given method

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->