### PR TITLE
Automatic Smart Wallet network switching // Require chain id lowest level

### DIFF
--- a/Thirdweb.Tests/Thirdweb.Extensions/Thirdweb.Extensions.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Extensions/Thirdweb.Extensions.Tests.cs
@@ -198,6 +198,59 @@ public class ExtensionsTests : BaseTests
     }
 
     [Fact(Timeout = 120000)]
+    public async Task GetTransactionCountRaw()
+    {
+        var address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; // vitalik.eth
+        var chainId = BigInteger.One;
+        var transactionCount = await ThirdwebExtensions.GetTransactionCountRaw(this._client, chainId, address);
+        Assert.True(transactionCount >= 0);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task GetTransactionCountRaw_WithBlockTag()
+    {
+        var address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; // vitalik.eth
+        var chainId = this._chainId;
+        var blockTag = "latest";
+        var transactionCount = await ThirdwebExtensions.GetTransactionCountRaw(this._client, chainId, address, blockTag);
+        Assert.True(transactionCount >= 0);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task GetTransactionCount_Contract()
+    {
+        var contract = await this.GetTokenERC20Contract();
+        var transactionCount = await contract.GetTransactionCount();
+        Assert.True(transactionCount >= 0);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task GetTransactionCount_Contract_WithBlockTag()
+    {
+        var contract = await this.GetTokenERC20Contract();
+        var blockTag = "latest";
+        var transactionCount = await contract.GetTransactionCount(blockTag);
+        Assert.True(transactionCount >= 0);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task GetTransactionCount_Wallet()
+    {
+        var wallet = await this.GetSmartWallet();
+        var transactionCount = await wallet.GetTransactionCount(this._chainId);
+        Assert.True(transactionCount >= 0);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task GetTransactionCount_Wallet_WithBlockTag()
+    {
+        var wallet = await this.GetSmartWallet();
+        var blockTag = "latest";
+        var transactionCount = await wallet.GetTransactionCount(this._chainId, blockTag);
+        Assert.True(transactionCount >= 0);
+    }
+
+    [Fact(Timeout = 120000)]
     public async Task Transfer()
     {
         _ = ThirdwebClient.Create(secretKey: this.SecretKey);

--- a/Thirdweb.Tests/Thirdweb.Transactions/Thirdweb.ZkSmartWallet.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Transactions/Thirdweb.ZkSmartWallet.Tests.cs
@@ -78,7 +78,7 @@ public class ZkSmartWalletTests : BaseTests
     {
         var account = await this.GetSmartAccount();
         var hash = await account.SendTransaction(
-            new ThirdwebTransactionInput()
+            new ThirdwebTransactionInput(300)
             {
                 From = await account.GetAddress(),
                 To = await account.GetAddress(),
@@ -90,29 +90,12 @@ public class ZkSmartWalletTests : BaseTests
         Assert.True(hash.Length == 66);
     }
 
-    // [Fact(Timeout = 120000)]
-    // public async Task SendGaslessZkTx_ZkCandy_Success()
-    // {
-    //     var account = await GetSmartAccount(zkChainId: 302);
-    //     var hash = await account.SendTransaction(
-    //         new ThirdwebTransactionInput()
-    //         {
-    //             From = await account.GetAddress(),
-    //             To = await account.GetAddress(),
-    //             Value = new Nethereum.Hex.HexTypes.HexBigInteger(0),
-    //             Data = "0x"
-    //         }
-    //     );
-    //     Assert.NotNull(hash);
-    //     Assert.True(hash.Length == 66);
-    // }
-
     [Fact(Timeout = 120000)]
-    public async Task SendGaslessZkTx_Abstract_Success()
+    public async Task SendGaslessZkTx_ZkCandy_Success()
     {
-        var account = await this.GetSmartAccount(zkChainId: 11124);
+        var account = await this.GetSmartAccount(zkChainId: 302);
         var hash = await account.SendTransaction(
-            new ThirdwebTransactionInput()
+            new ThirdwebTransactionInput(302)
             {
                 From = await account.GetAddress(),
                 To = await account.GetAddress(),
@@ -122,5 +105,37 @@ public class ZkSmartWalletTests : BaseTests
         );
         Assert.NotNull(hash);
         Assert.True(hash.Length == 66);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SendGaslessZkTx_Abstract_Success()
+    {
+        var account = await this.GetSmartAccount(zkChainId: 11124);
+        var hash = await account.SendTransaction(
+            new ThirdwebTransactionInput(11124)
+            {
+                From = await account.GetAddress(),
+                To = await account.GetAddress(),
+                Value = new Nethereum.Hex.HexTypes.HexBigInteger(0),
+                Data = "0x"
+            }
+        );
+        Assert.NotNull(hash);
+        Assert.True(hash.Length == 66);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task ZkSync_Switch()
+    {
+        var account = await this.GetSmartAccount(zkChainId: 300);
+        _ = await account.SendTransaction(
+            new ThirdwebTransactionInput(302)
+            {
+                From = await account.GetAddress(),
+                To = await account.GetAddress(),
+                Value = new Nethereum.Hex.HexTypes.HexBigInteger(0),
+                Data = "0x"
+            }
+        );
     }
 }

--- a/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.PrivateKeyWallet.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.PrivateKeyWallet.Tests.cs
@@ -168,7 +168,7 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
     public async Task SignTransaction_Success()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(421614)
         {
             From = await account.GetAddress(),
             To = Constants.ADDRESS_ZERO,
@@ -177,7 +177,6 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
             // Data = "0x",
             Nonce = new HexBigInteger(99999999999),
             GasPrice = new HexBigInteger(10000000000),
-            ChainId = new HexBigInteger(421614)
         };
         var signature = await account.SignTransaction(transaction);
         Assert.NotNull(signature);
@@ -187,7 +186,7 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
     public async Task SignTransaction_NoFrom_Success()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(421614)
         {
             To = Constants.ADDRESS_ZERO,
             // Value = new HexBigInteger(0),
@@ -195,7 +194,6 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
             Data = "0x",
             Nonce = new HexBigInteger(99999999999),
             GasPrice = new HexBigInteger(10000000000),
-            ChainId = new HexBigInteger(421614)
         };
         var signature = await account.SignTransaction(transaction);
         Assert.NotNull(signature);
@@ -213,7 +211,7 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
     public async Task SignTransaction_NoNonce()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(421614)
         {
             From = await account.GetAddress(),
             To = Constants.ADDRESS_ZERO,
@@ -229,7 +227,7 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
     public async Task SignTransaction_NoGasPrice()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(421614)
         {
             From = await account.GetAddress(),
             To = Constants.ADDRESS_ZERO,
@@ -247,7 +245,7 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
     public async Task SignTransaction_1559_Success()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(421614)
         {
             From = await account.GetAddress(),
             To = Constants.ADDRESS_ZERO,
@@ -257,7 +255,6 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
             Nonce = new HexBigInteger(99999999999),
             MaxFeePerGas = new HexBigInteger(10000000000),
             MaxPriorityFeePerGas = new HexBigInteger(10000000000),
-            ChainId = new HexBigInteger(421614)
         };
         var signature = await account.SignTransaction(transaction);
         Assert.NotNull(signature);
@@ -267,7 +264,7 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
     public async Task SignTransaction_1559_NoMaxFeePerGas()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(421614)
         {
             From = await account.GetAddress(),
             To = Constants.ADDRESS_ZERO,
@@ -276,7 +273,6 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
             Data = "0x",
             Nonce = new HexBigInteger(99999999999),
             MaxPriorityFeePerGas = new HexBigInteger(10000000000),
-            ChainId = new HexBigInteger(421614)
         };
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => account.SignTransaction(transaction));
         Assert.Equal("Transaction MaxPriorityFeePerGas and MaxFeePerGas must be set for EIP-1559 transactions", ex.Message);
@@ -286,7 +282,7 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
     public async Task SignTransaction_1559_NoMaxPriorityFeePerGas()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(421614)
         {
             From = await account.GetAddress(),
             To = Constants.ADDRESS_ZERO,
@@ -295,7 +291,6 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
             Data = "0x",
             Nonce = new HexBigInteger(99999999999),
             MaxFeePerGas = new HexBigInteger(10000000000),
-            ChainId = new HexBigInteger(421614)
         };
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => account.SignTransaction(transaction));
         Assert.Equal("Transaction MaxPriorityFeePerGas and MaxFeePerGas must be set for EIP-1559 transactions", ex.Message);
@@ -344,7 +339,7 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
     public async Task SendTransaction_InvalidOperation()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(421614)
         {
             From = await account.GetAddress(),
             To = Constants.ADDRESS_ZERO,
@@ -358,7 +353,7 @@ public class PrivateKeyWalletTests(ITestOutputHelper output) : BaseTests(output)
     public async Task ExecuteTransaction_InvalidOperation()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(421614)
         {
             From = await account.GetAddress(),
             To = Constants.ADDRESS_ZERO,

--- a/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.SmartWallet.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.SmartWallet.Tests.cs
@@ -82,7 +82,7 @@ public class SmartWalletTests : BaseTests
     public async Task ExecuteTransaction_Success()
     {
         var account = await this.GetSmartAccount();
-        var tx = await account.ExecuteTransaction(new ThirdwebTransactionInput() { To = await account.GetAddress() });
+        var tx = await account.ExecuteTransaction(new ThirdwebTransactionInput(421614) { To = await account.GetAddress() });
         Assert.NotNull(tx);
     }
 
@@ -90,7 +90,7 @@ public class SmartWalletTests : BaseTests
     public async Task SendTransaction_Success()
     {
         var account = await this.GetSmartAccount();
-        var tx = await account.SendTransaction(new ThirdwebTransactionInput() { To = await account.GetAddress(), });
+        var tx = await account.SendTransaction(new ThirdwebTransactionInput(421614) { To = await account.GetAddress(), });
         Assert.NotNull(tx);
     }
 
@@ -100,7 +100,7 @@ public class SmartWalletTests : BaseTests
         var client = ThirdwebClient.Create(clientId: this.ClientIdBundleIdOnly, bundleId: this.BundleIdBundleIdOnly);
         var privateKeyAccount = await PrivateKeyWallet.Generate(client);
         var smartAccount = await SmartWallet.Create(personalWallet: privateKeyAccount, factoryAddress: "0xbf1C9aA4B1A085f7DA890a44E82B0A1289A40052", gasless: true, chainId: 421614);
-        var tx = await smartAccount.SendTransaction(new ThirdwebTransactionInput() { To = await smartAccount.GetAddress(), });
+        var tx = await smartAccount.SendTransaction(new ThirdwebTransactionInput(421614) { To = await smartAccount.GetAddress(), });
         Assert.NotNull(tx);
     }
 
@@ -170,7 +170,7 @@ public class SmartWalletTests : BaseTests
         var account = await this.GetSmartAccount();
         var receipt = await account.CreateSessionKey(
             signerAddress: "0x253d077C45A3868d0527384e0B34e1e3088A3908",
-            approvedTargets: [Constants.ADDRESS_ZERO],
+            approvedTargets: new List<string> { Constants.ADDRESS_ZERO },
             nativeTokenLimitPerTransactionInWei: "0",
             permissionStartTimestamp: "0",
             permissionEndTimestamp: (Utils.GetUnixTimeStampNow() + 86400).ToString(),
@@ -229,7 +229,7 @@ public class SmartWalletTests : BaseTests
         var randomSigner = await (await PrivateKeyWallet.Generate(this._client)).GetAddress();
         _ = await account.CreateSessionKey(
             signerAddress: randomSigner,
-            approvedTargets: [Constants.ADDRESS_ZERO],
+            approvedTargets: new List<string>() { Constants.ADDRESS_ZERO },
             nativeTokenLimitPerTransactionInWei: "0",
             permissionStartTimestamp: "0",
             permissionEndTimestamp: (Utils.GetUnixTimeStampNow() + 86400).ToString(),
@@ -285,9 +285,47 @@ public class SmartWalletTests : BaseTests
             entryPoint: Constants.ENTRYPOINT_ADDRESS_V07
         );
 
-        var hash07 = await smartWallet07.SendTransaction(new ThirdwebTransactionInput() { To = await smartWallet07.GetAddress(), });
+        var hash07 = await smartWallet07.SendTransaction(new ThirdwebTransactionInput(11155111) { To = await smartWallet07.GetAddress(), });
 
         Assert.NotNull(hash07);
         Assert.True(hash07.Length == 66);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task MultiChainTransaction_Success()
+    {
+        var chainId1 = 11155111;
+        var chainId2 = 421614;
+
+        var smartWallet = await SmartWallet.Create(
+            personalWallet: await PrivateKeyWallet.Generate(this._client),
+            chainId: chainId1,
+            gasless: true,
+            factoryAddress: Constants.DEFAULT_FACTORY_ADDRESS_V06,
+            entryPoint: Constants.ENTRYPOINT_ADDRESS_V06
+        );
+
+        var address1 = await smartWallet.GetAddress();
+        var receipt1 = await smartWallet.ExecuteTransaction(new ThirdwebTransactionInput(chainId1) { To = address1, });
+        var nonce1 = await smartWallet.GetTransactionCount(chainId: chainId1, blocktag: "latest");
+
+        var address2 = await smartWallet.GetAddress();
+        var receipt2 = await smartWallet.ExecuteTransaction(new ThirdwebTransactionInput(chainId2) { To = address2, });
+        var nonce2 = await smartWallet.GetTransactionCount(chainId: chainId2, blocktag: "latest");
+
+        Assert.NotNull(address1);
+        Assert.NotNull(address2);
+        Assert.Equal(address1, address2);
+
+        Assert.NotNull(receipt1);
+        Assert.NotNull(receipt2);
+
+        Assert.True(receipt1.TransactionHash.Length == 66);
+        Assert.True(receipt2.TransactionHash.Length == 66);
+
+        Assert.Equal(receipt1.To, receipt2.To);
+
+        Assert.Equal(nonce1, 1);
+        Assert.Equal(nonce2, 1);
     }
 }

--- a/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.Wallets.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.Wallets.Tests.cs
@@ -61,7 +61,7 @@ public class WalletTests : BaseTests
     [Fact(Timeout = 120000)]
     public async Task PersonalSign()
     {
-        var wallet = await this.GetSmartAccount();
+        var wallet = await this.GetPrivateKeyAccount();
         var message = "Hello, world!";
         var signature = await wallet.PersonalSign(message);
         Assert.NotNull(signature);

--- a/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.Wallets.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.Wallets.Tests.cs
@@ -122,7 +122,7 @@ public class WalletTests : BaseTests
     public async Task SignTransaction()
     {
         var wallet = await this.GetSmartAccount();
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(421614)
         {
             To = await wallet.GetAddress(),
             Data = "0x",
@@ -130,7 +130,6 @@ public class WalletTests : BaseTests
             Gas = new HexBigInteger(21000),
             GasPrice = new HexBigInteger(10000000000),
             Nonce = new HexBigInteger(9999999999999),
-            ChainId = new HexBigInteger(421614),
         };
         _ = ThirdwebRPC.GetRpcInstance(ThirdwebClient.Create(secretKey: this.SecretKey), 421614);
         var signature = await wallet.SignTransaction(transaction);
@@ -174,7 +173,7 @@ public class WalletTests : BaseTests
         var typedData = EIP712.GetTypedDefinition_SmartAccount_AccountMessage("Account", "1", 421614, await wallet.GetAddress());
         var accountMessage = new AccountAbstraction.AccountMessage { Message = System.Text.Encoding.UTF8.GetBytes("Hello, world!").HashPrefixedMessage() };
         var signature = await wallet.SignTypedDataV4(accountMessage, typedData);
-        var recoveredAddress = await wallet.RecoverAddressFromTypedDataV4<AccountAbstraction.AccountMessage, Nethereum.ABI.EIP712.Domain>(accountMessage, typedData, signature);
+        var recoveredAddress = await wallet.RecoverAddressFromTypedDataV4(accountMessage, typedData, signature);
         Assert.Equal(await wallet.GetAddress(), recoveredAddress);
     }
 
@@ -232,7 +231,7 @@ public class WalletTests : BaseTests
         );
         _ = await Assert.ThrowsAsync<ArgumentNullException>(
             async () =>
-                await wallet.RecoverAddressFromTypedDataV4<AccountAbstraction.SignerPermissionRequest, Nethereum.ABI.EIP712.Domain>(
+                await wallet.RecoverAddressFromTypedDataV4(
                     new AccountAbstraction.SignerPermissionRequest(),
                     nullTypedData,
                     nullSig
@@ -240,7 +239,7 @@ public class WalletTests : BaseTests
         );
         _ = await Assert.ThrowsAsync<ArgumentNullException>(
             async () =>
-                await wallet.RecoverAddressFromTypedDataV4<AccountAbstraction.SignerPermissionRequest, Nethereum.ABI.EIP712.Domain>(
+                await wallet.RecoverAddressFromTypedDataV4(
                     new AccountAbstraction.SignerPermissionRequest(),
                     new Nethereum.ABI.EIP712.TypedData<Nethereum.ABI.EIP712.Domain>(),
                     nullSig

--- a/Thirdweb/Thirdweb.Contracts/ThirdwebContract.cs
+++ b/Thirdweb/Thirdweb.Contracts/ThirdwebContract.cs
@@ -150,14 +150,14 @@ public class ThirdwebContract
         }
 
         var data = function.GetData(parameters);
-        var transaction = new ThirdwebTransactionInput
+        var transaction = new ThirdwebTransactionInput(chainId: contract.Chain)
         {
             To = contract.Address,
             Data = data,
             Value = new HexBigInteger(weiValue),
         };
 
-        return await ThirdwebTransaction.Create(wallet, transaction, contract.Chain).ConfigureAwait(false);
+        return await ThirdwebTransaction.Create(wallet, transaction).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Thirdweb/Thirdweb.Pay/ThirdwebPay.BuyWithCrypto.cs
+++ b/Thirdweb/Thirdweb.Pay/ThirdwebPay.BuyWithCrypto.cs
@@ -26,7 +26,7 @@ public partial class ThirdwebPay
             }
         }
 
-        var txInput = new ThirdwebTransactionInput()
+        var txInput = new ThirdwebTransactionInput(chainId: buyWithCryptoQuote.TransactionRequest.ChainId)
         {
             To = buyWithCryptoQuote.TransactionRequest.To,
             Data = buyWithCryptoQuote.TransactionRequest.Data,
@@ -35,7 +35,7 @@ public partial class ThirdwebPay
             GasPrice = new HexBigInteger(BigInteger.Parse(buyWithCryptoQuote.TransactionRequest.GasPrice)),
         };
 
-        var tx = await ThirdwebTransaction.Create(wallet, txInput, buyWithCryptoQuote.TransactionRequest.ChainId);
+        var tx = await ThirdwebTransaction.Create(wallet, txInput);
 
         var hash = await ThirdwebTransaction.Send(tx);
 

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransactionInput.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransactionInput.cs
@@ -10,9 +10,13 @@ namespace Thirdweb;
 /// </summary>
 public class ThirdwebTransactionInput
 {
-    public ThirdwebTransactionInput() { }
+    public ThirdwebTransactionInput(BigInteger chainId)
+    {
+        this.ChainId = chainId > 0 ? new HexBigInteger(chainId) : throw new ArgumentException("Invalid Chain ID");
+    }
 
     public ThirdwebTransactionInput(
+        BigInteger chainId,
         string from = null,
         string to = null,
         BigInteger? nonce = null,
@@ -20,12 +24,12 @@ public class ThirdwebTransactionInput
         BigInteger? gasPrice = null,
         BigInteger? value = null,
         string data = null,
-        BigInteger? chainId = null,
         BigInteger? maxFeePerGas = null,
         BigInteger? maxPriorityFeePerGas = null,
         ZkSyncOptions? zkSync = null
     )
     {
+        this.ChainId = chainId > 0 ? new HexBigInteger(chainId) : throw new ArgumentException("Invalid Chain ID");
         this.From = string.IsNullOrEmpty(from) ? Constants.ADDRESS_ZERO : from;
         this.To = string.IsNullOrEmpty(to) ? Constants.ADDRESS_ZERO : to;
         this.Nonce = nonce == null ? null : new HexBigInteger(nonce.Value);
@@ -33,7 +37,6 @@ public class ThirdwebTransactionInput
         this.GasPrice = gasPrice == null ? null : new HexBigInteger(gasPrice.Value);
         this.Value = value == null ? null : new HexBigInteger(value.Value);
         this.Data = string.IsNullOrEmpty(data) ? "0x" : data;
-        this.ChainId = chainId == null ? null : new HexBigInteger(chainId.Value);
         this.MaxFeePerGas = maxFeePerGas == null ? null : new HexBigInteger(maxFeePerGas.Value);
         this.MaxPriorityFeePerGas = maxPriorityFeePerGas == null ? null : new HexBigInteger(maxPriorityFeePerGas.Value);
         this.ZkSync = zkSync;

--- a/Thirdweb/Thirdweb.Utils/Utils.cs
+++ b/Thirdweb/Thirdweb.Utils/Utils.cs
@@ -392,6 +392,11 @@ public static partial class Utils
 
     public static int GetEntryPointVersion(string address)
     {
+        if (address == null)
+        {
+            return 6; // non-4337
+        }
+
         address = address.ToChecksumAddress();
         return address switch
         {


### PR DESCRIPTION
Assumes deterministic factory, not supported with erc20 pm, supported for zksync chains

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor transaction input handling and improve chain ID management in the Thirdweb project.

### Detailed summary
- Refactored transaction input constructors to include chain ID
- Improved chain ID validation and handling in transaction creation
- Updated tests to reflect changes in transaction input handling

> The following files were skipped due to too many changes: `Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.Wallets.Tests.cs`, `Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.SmartWallet.Tests.cs`, `Thirdweb/Thirdweb.Extensions/ThirdwebExtensions.cs`, `Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.PrivateKeyWallet.Tests.cs`, `Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs`, `Thirdweb.Tests/Thirdweb.Transactions/Thirdweb.Transactions.Tests.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->