### PR TITLE
Allow raw pm-less zksync serialized txs

### DIFF
--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -86,13 +86,38 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 
 #endregion
 
-// #region Maximum low level zksync tx
+#region Maximum low level zksync tx
 
 // var chainId = 300;
 
 // var zkRawWallet = await PrivateKeyWallet.Generate(client: client);
 // var zkRawAddy = await zkRawWallet.GetAddress();
 // Console.WriteLine($"ZkSync raw address: {zkRawAddy}");
+
+// // Less raw example
+
+// var zkRawTx = await ThirdwebTransaction.Create(
+//     wallet: zkRawWallet,
+//     txInput: new ThirdwebTransactionInput(
+//         chainId: chainId,
+//         from: zkRawAddy,
+//         to: zkRawAddy,
+//         value: 0,
+//         data: "0x",
+//         zkSync: new ZkSyncOptions(paymaster: null, paymasterInput: null, gasPerPubdataByteLimit: 50000)
+//     )
+// );
+
+// zkRawTx = await ThirdwebTransaction.Prepare(zkRawTx);
+
+// Console.WriteLine($"ZkSync raw transaction: {zkRawTx}");
+// Console.WriteLine("Make sure you have enough funds!");
+// Console.ReadLine();
+
+// var hash = await ThirdwebTransaction.Send(zkRawTx);
+// Console.WriteLine($"Transaction hash: {hash}");
+
+// // Extremely raw example
 
 // var zkRawTx = new Thirdweb.AccountAbstraction.ZkSyncAATransaction
 // {
@@ -104,7 +129,7 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 //     MaxFeePerGas = 1000000000,
 //     MaxPriorityFeePerGas = 1000000000,
 //     Paymaster = 0,
-//     Nonce = 1,
+//     Nonce = 0,
 //     Value = 0,
 //     Data = new byte[] { 0x00 },
 //     FactoryDeps = new List<byte[]>(),
@@ -120,7 +145,7 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 // var hash = await rpcInstance.SendRequestAsync<string>("eth_sendRawTransaction", signedZkRawTx);
 // Console.WriteLine($"Transaction hash: {hash}");
 
-// #endregion
+#endregion
 
 #region Account Linking
 

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -86,6 +86,42 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 
 #endregion
 
+// #region Maximum low level zksync tx
+
+// var chainId = 300;
+
+// var zkRawWallet = await PrivateKeyWallet.Generate(client: client);
+// var zkRawAddy = await zkRawWallet.GetAddress();
+// Console.WriteLine($"ZkSync raw address: {zkRawAddy}");
+
+// var zkRawTx = new Thirdweb.AccountAbstraction.ZkSyncAATransaction
+// {
+//     TxType = 0x71,
+//     From = new HexBigInteger(zkRawAddy).Value,
+//     To = new HexBigInteger(zkRawAddy).Value,
+//     GasLimit = 250000,
+//     GasPerPubdataByteLimit = 50000,
+//     MaxFeePerGas = 1000000000,
+//     MaxPriorityFeePerGas = 1000000000,
+//     Paymaster = 0,
+//     Nonce = 1,
+//     Value = 0,
+//     Data = new byte[] { 0x00 },
+//     FactoryDeps = new List<byte[]>(),
+//     PaymasterInput = Array.Empty<byte>(),
+// };
+// var signedZkRawTx = await EIP712.GenerateSignature_ZkSyncTransaction("zkSync", "2", chainId, zkRawTx, zkRawWallet);
+
+// Console.WriteLine($"ZkSync raw transaction: {JsonConvert.SerializeObject(zkRawTx, Formatting.Indented)}");
+// Console.WriteLine("Make sure you have enough funds!");
+// Console.ReadLine();
+
+// var rpcInstance = ThirdwebRPC.GetRpcInstance(client, chainId);
+// var hash = await rpcInstance.SendRequestAsync<string>("eth_sendRawTransaction", signedZkRawTx);
+// Console.WriteLine($"Transaction hash: {hash}");
+
+// #endregion
+
 #region Account Linking
 
 // var inAppWalletMain = await InAppWallet.Create(client: client, authProvider: AuthProvider.Google);

--- a/Thirdweb.Tests/Thirdweb.Transactions/Thirdweb.Transactions.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Transactions/Thirdweb.Transactions.Tests.cs
@@ -201,17 +201,17 @@ public class TransactionTests(ITestOutputHelper output) : BaseTests(output)
         transaction = await this.CreateSampleTransaction();
         _ = transaction.SetZkSyncOptions(new ZkSyncOptions(paymaster: null, paymasterInput: "0x"));
         Assert.Equal(0, transaction.Input.ZkSync?.Paymaster);
-        Assert.Null(transaction.Input.ZkSync?.PaymasterInput);
+        Assert.Equal(transaction.Input.ZkSync?.PaymasterInput, Array.Empty<byte>());
         Assert.Null(transaction.Input.ZkSync?.GasPerPubdataByteLimit);
-        Assert.Null(transaction.Input.ZkSync?.FactoryDeps);
+        Assert.Equal(transaction.Input.ZkSync?.FactoryDeps, new List<byte[]>());
 
         // PaymasterInput null
         transaction = await this.CreateSampleTransaction();
         _ = transaction.SetZkSyncOptions(new ZkSyncOptions(paymaster: "0x", paymasterInput: null));
         Assert.Equal(0, transaction.Input.ZkSync?.Paymaster);
-        Assert.Null(transaction.Input.ZkSync?.PaymasterInput);
+        Assert.Equal(transaction.Input.ZkSync?.PaymasterInput, Array.Empty<byte>());
         Assert.Null(transaction.Input.ZkSync?.GasPerPubdataByteLimit);
-        Assert.Null(transaction.Input.ZkSync?.FactoryDeps);
+        Assert.Equal(transaction.Input.ZkSync?.FactoryDeps, new List<byte[]>());
     }
 
     [Fact(Timeout = 120000)]

--- a/Thirdweb.Tests/Thirdweb.Transactions/Thirdweb.ZkSmartWallet.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Transactions/Thirdweb.ZkSmartWallet.Tests.cs
@@ -90,22 +90,22 @@ public class ZkSmartWalletTests : BaseTests
         Assert.True(hash.Length == 66);
     }
 
-    [Fact(Timeout = 120000)]
-    public async Task SendGaslessZkTx_ZkCandy_Success()
-    {
-        var account = await this.GetSmartAccount(zkChainId: 302);
-        var hash = await account.SendTransaction(
-            new ThirdwebTransactionInput(302)
-            {
-                From = await account.GetAddress(),
-                To = await account.GetAddress(),
-                Value = new Nethereum.Hex.HexTypes.HexBigInteger(0),
-                Data = "0x"
-            }
-        );
-        Assert.NotNull(hash);
-        Assert.True(hash.Length == 66);
-    }
+    // [Fact(Timeout = 120000)]
+    // public async Task SendGaslessZkTx_ZkCandy_Success()
+    // {
+    //     var account = await this.GetSmartAccount(zkChainId: 302);
+    //     var hash = await account.SendTransaction(
+    //         new ThirdwebTransactionInput(302)
+    //         {
+    //             From = await account.GetAddress(),
+    //             To = await account.GetAddress(),
+    //             Value = new Nethereum.Hex.HexTypes.HexBigInteger(0),
+    //             Data = "0x"
+    //         }
+    //     );
+    //     Assert.NotNull(hash);
+    //     Assert.True(hash.Length == 66);
+    // }
 
     [Fact(Timeout = 120000)]
     public async Task SendGaslessZkTx_Abstract_Success()

--- a/Thirdweb.Tests/Thirdweb.Transactions/Thirdweb.ZkSmartWallet.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Transactions/Thirdweb.ZkSmartWallet.Tests.cs
@@ -27,7 +27,7 @@ public class ZkSmartWalletTests : BaseTests
     [Fact(Timeout = 120000)]
     public async Task PersonalSign_Success()
     {
-        var account = await this.GetSmartAccount(zkChainId: 302);
+        var account = await this.GetSmartAccount(zkChainId: 300);
         var message = "Hello, World!";
         var signature = await account.PersonalSign(message);
         Assert.NotNull(signature);
@@ -129,7 +129,7 @@ public class ZkSmartWalletTests : BaseTests
     {
         var account = await this.GetSmartAccount(zkChainId: 300);
         _ = await account.SendTransaction(
-            new ThirdwebTransactionInput(302)
+            new ThirdwebTransactionInput(11124)
             {
                 From = await account.GetAddress(),
                 To = await account.GetAddress(),

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
@@ -393,12 +393,7 @@ public class ThirdwebTransaction
 
         var rpc = ThirdwebRPC.GetRpcInstance(transaction._wallet.Client, transaction.Input.ChainId.Value);
         string hash;
-        if (
-            Utils.IsZkSync(transaction.Input.ChainId.Value)
-            && transaction.Input.ZkSync.HasValue
-            && transaction.Input.ZkSync.Value.Paymaster != 0
-            && transaction.Input.ZkSync.Value.PaymasterInput != null
-        )
+        if (Utils.IsZkSync(transaction.Input.ChainId.Value) && transaction.Input.ZkSync.HasValue)
         {
             var zkTx = await ConvertToZkSyncTransaction(transaction).ConfigureAwait(false);
             var zkTxSigned = await EIP712.GenerateSignature_ZkSyncTransaction("zkSync", "2", transaction.Input.ChainId.Value, zkTx, transaction._wallet).ConfigureAwait(false);

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
@@ -357,6 +357,7 @@ public class ThirdwebTransaction
             throw new InvalidOperationException("Transaction GasPrice and MaxFeePerGas/MaxPriorityFeePerGas cannot be set at the same time");
         }
 
+        transaction.Input.Nonce ??= new HexBigInteger(await GetNonce(transaction).ConfigureAwait(false));
         transaction.Input.Value ??= new HexBigInteger(0);
         transaction.Input.Data ??= "0x";
         transaction.Input.Gas ??= new HexBigInteger(await EstimateGasLimit(transaction).ConfigureAwait(false));
@@ -404,7 +405,6 @@ public class ThirdwebTransaction
             switch (transaction._wallet.AccountType)
             {
                 case ThirdwebAccountType.PrivateKeyAccount:
-                    transaction.Input.Nonce ??= new HexBigInteger(await GetNonce(transaction).ConfigureAwait(false));
                     var signedTx = await Sign(transaction);
                     hash = await rpc.SendRequestAsync<string>("eth_sendRawTransaction", signedTx).ConfigureAwait(false);
                     break;

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransactionInput.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransactionInput.cs
@@ -166,7 +166,9 @@ public struct ZkSyncOptions
         if (string.IsNullOrEmpty(paymaster) || string.IsNullOrEmpty(paymasterInput))
         {
             this.Paymaster = 0;
-            this.PaymasterInput = null;
+            this.PaymasterInput = Array.Empty<byte>();
+            this.GasPerPubdataByteLimit = gasPerPubdataByteLimit;
+            this.FactoryDeps = factoryDeps ?? new List<byte[]>();
         }
         else
         {

--- a/Thirdweb/Thirdweb.Wallets/EIP712.cs
+++ b/Thirdweb/Thirdweb.Wallets/EIP712.cs
@@ -366,7 +366,8 @@ public static class EIP712
             throw new ArgumentException("Chain ID must be provided for EIP712 transactions!");
         }
 
-        var fields = new List<byte[]> {
+        var fields = new List<byte[]>
+        {
             transaction.Nonce == 0 ? Array.Empty<byte>() : transaction.Nonce.ToByteArray(isUnsigned: true, isBigEndian: true),
             transaction.MaxPriorityFeePerGas == 0 ? Array.Empty<byte>() : transaction.MaxPriorityFeePerGas.ToByteArray(isUnsigned: true, isBigEndian: true),
             transaction.MaxFeePerGas.ToByteArray(isUnsigned: true, isBigEndian: true),
@@ -379,13 +380,14 @@ public static class EIP712
             signature.S,
             chainId.ToByteArray(isUnsigned: true, isBigEndian: true),
             transaction.From.ToByteArray(isUnsigned: true, isBigEndian: true),
-
             // Add meta
             transaction.GasPerPubdataByteLimit.ToByteArray(isUnsigned: true, isBigEndian: true),
             Array.Empty<byte>(), // TODO: FactoryDeps
             signature.CreateStringSignature().HexToByteArray(),
             // add array of rlp encoded paymaster/paymasterinput
-            RLP.EncodeElement(transaction.Paymaster.ToByteArray(isUnsigned: true, isBigEndian: true)).Concat(RLP.EncodeElement(transaction.PaymasterInput)).ToArray()
+            transaction.Paymaster != 0
+                ? RLP.EncodeElement(transaction.Paymaster.ToByteArray(isUnsigned: true, isBigEndian: true)).Concat(RLP.EncodeElement(transaction.PaymasterInput)).ToArray()
+                : Array.Empty<byte>()
         };
 
         return "0x71" + RLP.EncodeDataItemsAsElementOrListAndCombineAsList(fields.ToArray(), _indexOfListDataItems).ToHex();


### PR DESCRIPTION
For cases where only gas per pubdata is to be manually set
ZkSync users will definitely push the limits

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update transaction input handling in ZkSync options and EIP712 serialization.

### Detailed summary
- Updated `PaymasterInput` initialization in `ThirdwebTransactionInput`
- Adjusted assertions in tests for `PaymasterInput` and `FactoryDeps`
- Improved serialization in `SerializeEip712` method
- Refactored transaction input initialization in `ThirdwebTransaction`
- Enhanced handling of ZkSync transactions in `Send` method
- Modified test cases in `Thirdweb.ZkSmartWallet.Tests`
- Added comments in `Program.cs` for ZkSync transaction examples

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->