### PR TITLE
Login with X

### DIFF
--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -302,7 +302,7 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 
 #region InAppWallet - OAuth
 
-// var inAppWalletOAuth = await InAppWallet.Create(client: client, authProvider: AuthProvider.Line);
+// var inAppWalletOAuth = await InAppWallet.Create(client: client, authProvider: AuthProvider.X);
 // if (!await inAppWalletOAuth.IsConnected())
 // {
 //     _ = await inAppWalletOAuth.LoginWithOauth(

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
@@ -77,6 +77,7 @@ public partial class EcosystemWallet : PrivateKeyWallet
             AuthProvider.Siwe => "Siwe",
             AuthProvider.Line => "Line",
             AuthProvider.Guest => "Guest",
+            AuthProvider.X => "X",
             AuthProvider.Default => string.IsNullOrEmpty(email) ? "Phone" : "Email",
             _ => throw new ArgumentException("Invalid AuthProvider"),
         };
@@ -304,6 +305,7 @@ public partial class EcosystemWallet : PrivateKeyWallet
             case "Farcaster":
             case "Telegram":
             case "Line":
+            case "X":
                 serverRes = await walletToLink.PreAuth_OAuth(isMobile ?? false, browserOpenAction, mobileRedirectScheme, browser).ConfigureAwait(false);
                 break;
             default:

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs
@@ -22,7 +22,8 @@ public enum AuthProvider
     Telegram,
     Siwe,
     Line,
-    Guest
+    Guest,
+    X
 }
 
 public struct LinkedAccount
@@ -103,6 +104,7 @@ public class InAppWallet : PrivateKeyWallet
             Thirdweb.AuthProvider.Siwe => "Siwe",
             Thirdweb.AuthProvider.Line => "Line",
             Thirdweb.AuthProvider.Guest => "Guest",
+            Thirdweb.AuthProvider.X => "X",
             Thirdweb.AuthProvider.Default => string.IsNullOrEmpty(email) ? "Phone" : "Email",
             _ => throw new ArgumentException("Invalid AuthProvider"),
         };
@@ -227,6 +229,7 @@ public class InAppWallet : PrivateKeyWallet
             case "Farcaster":
             case "Telegram":
             case "Line":
+            case "X":
                 serverRes = await walletToLink.PreAuth_OAuth(isMobile ?? false, browserOpenAction, mobileRedirectScheme, browser).ConfigureAwait(false);
                 break;
             default:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add support for a new authentication provider "X" in the InAppWallet ecosystem.

### Detailed summary
- Added support for authentication provider "X" in `EcosystemWallet` and `InAppWallet`
- Updated `AuthProvider` enum to include "X" in both files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->