### PR TITLE
Expose linking functionality at IThirdwebWallet level

### DIFF
--- a/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
@@ -129,6 +129,20 @@ public interface IThirdwebWallet
     /// Disconnects the wallet (if using InAppWallet, clears session)
     /// </summary>
     Task Disconnect();
+
+    Task<List<LinkedAccount>> LinkAccount(
+        IThirdwebWallet walletToLink,
+        string otp = null,
+        bool? isMobile = null,
+        Action<string> browserOpenAction = null,
+        string mobileRedirectScheme = "thirdweb://",
+        IThirdwebBrowser browser = null,
+        System.Numerics.BigInteger? chainId = null,
+        string jwt = null,
+        string payload = null
+    );
+
+    Task<List<LinkedAccount>> GetLinkedAccounts();
 }
 
 /// <summary>

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using System.Text;
 using Nethereum.ABI.EIP712;
 using Nethereum.Hex.HexConvertors.Extensions;
@@ -357,6 +358,26 @@ public class PrivateKeyWallet : IThirdwebWallet
     public virtual Task<ThirdwebTransactionReceipt> ExecuteTransaction(ThirdwebTransactionInput transactionInput)
     {
         throw new InvalidOperationException("ExecuteTransaction is not supported for private key wallets, please use the unified Contract or ThirdwebTransaction APIs.");
+    }
+
+    public virtual Task<List<LinkedAccount>> LinkAccount(
+        IThirdwebWallet walletToLink,
+        string otp = null,
+        bool? isMobile = null,
+        Action<string> browserOpenAction = null,
+        string mobileRedirectScheme = "thirdweb://",
+        IThirdwebBrowser browser = null,
+        BigInteger? chainId = null,
+        string jwt = null,
+        string payload = null
+    )
+    {
+        throw new InvalidOperationException("LinkAccount is not supported for private key wallets.");
+    }
+
+    public virtual Task<List<LinkedAccount>> GetLinkedAccounts()
+    {
+        throw new InvalidOperationException("GetLinkedAccounts is not supported for private key wallets.");
     }
 
     #endregion

--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -1014,4 +1014,52 @@ public class SmartWallet : IThirdwebWallet
         this._accountContract = null;
         return Task.CompletedTask;
     }
+
+    public async Task<List<LinkedAccount>> LinkAccount(
+        IThirdwebWallet walletToLink,
+        string otp = null,
+        bool? isMobile = null,
+        Action<string> browserOpenAction = null,
+        string mobileRedirectScheme = "thirdweb://",
+        IThirdwebBrowser browser = null,
+        BigInteger? chainId = null,
+        string jwt = null,
+        string payload = null
+    )
+    {
+        var personalWallet = await this.GetPersonalWallet().ConfigureAwait(false);
+        if (personalWallet is not InAppWallet and not EcosystemWallet)
+        {
+            throw new Exception("SmartWallet.LinkAccount is only supported if the signer is an InAppWallet or EcosystemWallet");
+        }
+        else if (walletToLink is not InAppWallet and not EcosystemWallet)
+        {
+            throw new Exception("SmartWallet.LinkAccount is only supported if the wallet to link is an InAppWallet or EcosystemWallet");
+        }
+        else if (personalWallet is InAppWallet && walletToLink is not InAppWallet)
+        {
+            throw new Exception("SmartWallet.LinkAccount with an InAppWallet signer is only supported if the wallet to link is also an InAppWallet");
+        }
+        else if (personalWallet is EcosystemWallet && walletToLink is not EcosystemWallet)
+        {
+            throw new Exception("SmartWallet.LinkAccount with an EcosystemWallet signer is only supported if the wallet to link is also an EcosystemWallet");
+        }
+        else
+        {
+            return await personalWallet.LinkAccount(walletToLink, otp, isMobile, browserOpenAction, mobileRedirectScheme, browser, chainId, jwt, payload).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<List<LinkedAccount>> GetLinkedAccounts()
+    {
+        var personalWallet = await this.GetPersonalWallet().ConfigureAwait(false);
+        if (personalWallet is not InAppWallet and not EcosystemWallet)
+        {
+            throw new Exception("SmartWallet.LinkAccount is only supported if the signer is an InAppWallet or EcosystemWallet");
+        }
+        else
+        {
+            return await personalWallet.GetLinkedAccounts().ConfigureAwait(false);
+        }
+    }
 }


### PR DESCRIPTION
Improve dx, less casting requirements
Also removes the need to call SmartWallet.GetPersonalWallet to fetch linked accounts or link new ones with its signer

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the account linking functionality across various wallet implementations in the `Thirdweb` library. It introduces new methods for linking accounts and retrieving linked accounts while updating existing methods to support a more generalized wallet interface.

### Detailed summary
- Added `LinkAccount` and `GetLinkedAccounts` methods to `IThirdwebWallet`.
- Implemented `LinkAccount` and `GetLinkedAccounts` methods in `SmartWallet`.
- Updated `LinkAccount` in `InAppWallet` and `EcosystemWallet` to accept `IThirdwebWallet`.
- Added validation for wallet types in `SmartWallet` and updated error handling.
- Enhanced argument checks in `LinkAccount` methods across wallet classes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->