### PR TITLE
Remove blocktag from eth_estimateGas

### DIFF
--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
@@ -269,7 +269,7 @@ public class ThirdwebTransaction
         }
         else
         {
-            var hex = await rpc.SendRequestAsync<string>("eth_estimateGas", transaction.Input, "latest").ConfigureAwait(false);
+            var hex = await rpc.SendRequestAsync<string>("eth_estimateGas", transaction.Input).ConfigureAwait(false);
             return new HexBigInteger(hex).Value * 10 / 7;
         }
     }


### PR DESCRIPTION
Some chains like BNB Testnet do not support this

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `ThirdwebTransaction.cs` file to change the way the `eth_estimateGas` method is called, removing the "latest" parameter. This adjustment may impact how gas estimation is performed in the transaction processing.

### Detailed summary
- Removed the `"latest"` parameter from the `rpc.SendRequestAsync<string>("eth_estimateGas", transaction.Input)` call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->