### PR TITLE
IThirdwebWallet.Transfer Optional ERC20 Override

### DIFF
--- a/Thirdweb.Tests/Thirdweb.Extensions/Thirdweb.Extensions.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Extensions/Thirdweb.Extensions.Tests.cs
@@ -309,6 +309,16 @@ public class ExtensionsTests : BaseTests
     }
 
     [Fact(Timeout = 120000)]
+    public async Task TransferERC20Override()
+    {
+        var token = await this.GetTokenERC20Contract();
+        var wallet = await this.GetSmartWallet();
+        var receipt = await wallet.Transfer(this._chainId, await wallet.GetAddress(), BigInteger.Zero, token.Address);
+        Assert.NotNull(receipt);
+        Assert.True(receipt.TransactionHash.Length == 66);
+    }
+
+    [Fact(Timeout = 120000)]
     public async Task Contract_Read()
     {
         var contract = await this.GetTokenERC20Contract();


### PR DESCRIPTION
An alternative to ERC20_Transfer that might make more sense to some people.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new test for transferring ERC20 tokens and modifies the `Transfer` method to handle both native tokens and ERC20 tokens based on an optional `tokenAddress` parameter.

### Detailed summary
- Added a new test method `TransferERC20Override` in `Thirdweb.Extensions.Tests.cs`.
- Updated XML documentation for the `Transfer` method to describe ERC20 token transfer.
- Modified the `Transfer` method to accept an optional `tokenAddress` parameter.
- Implemented logic to transfer ERC20 tokens if `tokenAddress` is provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->