### PR TITLE
Make ERC1155 Transfer Data Field Optional

### DIFF
--- a/Thirdweb/Thirdweb.Extensions/ThirdwebExtensions.cs
+++ b/Thirdweb/Thirdweb.Extensions/ThirdwebExtensions.cs
@@ -1031,7 +1031,7 @@ public static class ThirdwebExtensions
         string toAddress,
         BigInteger tokenId,
         BigInteger amount,
-        byte[] data
+        byte[] data = null
     )
     {
         if (contract == null)
@@ -1056,7 +1056,7 @@ public static class ThirdwebExtensions
 
         return tokenId < 0
             ? throw new ArgumentOutOfRangeException(nameof(tokenId), "Token ID must be equal or greater than 0")
-            : await ThirdwebContract.Write(wallet, contract, "safeTransferFrom", 0, fromAddress, toAddress, tokenId, amount, data);
+            : await ThirdwebContract.Write(wallet, contract, "safeTransferFrom", 0, fromAddress, toAddress, tokenId, amount, data ?? Array.Empty<byte>());
     }
 
     /// <summary>
@@ -1079,7 +1079,7 @@ public static class ThirdwebExtensions
         string toAddress,
         BigInteger[] tokenIds,
         BigInteger[] amounts,
-        byte[] data
+        byte[] data = null
     )
     {
         if (contract == null)
@@ -1104,7 +1104,7 @@ public static class ThirdwebExtensions
 
         return tokenIds == null || amounts == null
             ? throw new ArgumentException("Token IDs and amounts must be provided")
-            : await ThirdwebContract.Write(wallet, contract, "safeBatchTransferFrom", 0, fromAddress, toAddress, tokenIds, amounts, data);
+            : await ThirdwebContract.Write(wallet, contract, "safeBatchTransferFrom", 0, fromAddress, toAddress, tokenIds, amounts, data ?? Array.Empty<byte>());
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the `ThirdwebExtensions.cs` file to set default values for the `data` parameter in two methods, ensuring that if `data` is not provided, an empty byte array is used instead. This change enhances the robustness of the methods by preventing potential null reference issues.

### Detailed summary
- In the method signature for `ERC1155_SafeTransferFrom`, changed `byte[] data` to `byte[] data = null`.
- Updated the method to use `data ?? Array.Empty<byte>()` instead of `data` when calling `ThirdwebContract.Write`.
- In the method signature for `ERC1155_SafeBatchTransferFrom`, changed `byte[] data` to `byte[] data = null`.
- Updated the method to use `data ?? Array.Empty<byte>()` instead of `data` when calling `ThirdwebContract.Write`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->