### PR TITLE
TokenPaymaster v3

### DIFF
--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -301,57 +301,42 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 
 #region TokenPaymaster - Celo CUSD
 
-// var erc20SmartWallet = await SmartWallet.Create(
-//     personalWallet: privateKeyWallet,
-//     chainId: 42220, // celo
-//     gasless: true,
-//     entryPoint: Constants.ENTRYPOINT_ADDRESS_V07,
-//     tokenPaymaster: TokenPaymaster.CELO_CUSD
-// );
+// var chainId = 42220; // celo
+
+// var erc20SmartWallet = await SmartWallet.Create(personalWallet: privateKeyWallet, chainId: chainId, tokenPaymaster: TokenPaymaster.CELO_CUSD);
+
 // var erc20SmartWalletAddress = await erc20SmartWallet.GetAddress();
 // Console.WriteLine($"ERC20 Smart Wallet address: {erc20SmartWalletAddress}");
 
-// var selfTransfer = await ThirdwebTransaction.Create(wallet: erc20SmartWallet, txInput: new ThirdwebTransactionInput(chainId: 42220, to: erc20SmartWalletAddress, value: 0, data: "0x"));
-
-// var receipt = await ThirdwebTransaction.SendAndWaitForTransactionReceipt(selfTransfer);
+// var receipt = await erc20SmartWallet.Transfer(chainId: chainId, toAddress: erc20SmartWalletAddress, weiAmount: 0);
 // Console.WriteLine($"Receipt: {JsonConvert.SerializeObject(receipt, Formatting.Indented)}");
 
 #endregion
 
 #region TokenPaymaster - Base USDC
 
-// var erc20SmartWallet = await SmartWallet.Create(
-//     personalWallet: privateKeyWallet,
-//     chainId: 8453, // base
-//     gasless: true,
-//     entryPoint: Constants.ENTRYPOINT_ADDRESS_V07,
-//     tokenPaymaster: TokenPaymaster.BASE_USDC
-// );
+// var chainId = 8453; // base
+
+// var erc20SmartWallet = await SmartWallet.Create(personalWallet: privateKeyWallet, chainId: chainId, tokenPaymaster: TokenPaymaster.BASE_USDC);
+
 // var erc20SmartWalletAddress = await erc20SmartWallet.GetAddress();
 // Console.WriteLine($"ERC20 Smart Wallet address: {erc20SmartWalletAddress}");
 
-// var selfTransfer = await ThirdwebTransaction.Create(wallet: erc20SmartWallet, txInput: new ThirdwebTransactionInput(chainId: 8453, to: erc20SmartWalletAddress, value: 0, data: "0x"));
-
-// var receipt = await ThirdwebTransaction.SendAndWaitForTransactionReceipt(selfTransfer);
+// var receipt = await erc20SmartWallet.Transfer(chainId: chainId, toAddress: erc20SmartWalletAddress, weiAmount: 0);
 // Console.WriteLine($"Receipt: {JsonConvert.SerializeObject(receipt, Formatting.Indented)}");
 
 #endregion
 
 #region TokenPaymaster - Lisk LSK
 
-// var erc20SmartWallet = await SmartWallet.Create(
-//     personalWallet: privateKeyWallet,
-//     chainId: 1135, // lisk
-//     gasless: true,
-//     entryPoint: Constants.ENTRYPOINT_ADDRESS_V07,
-//     tokenPaymaster: TokenPaymaster.LISK_LSK
-// );
+// var chainId = 1135; // lisk
+
+// var erc20SmartWallet = await SmartWallet.Create(personalWallet: privateKeyWallet, chainId: chainId, tokenPaymaster: TokenPaymaster.LISK_LSK);
+
 // var erc20SmartWalletAddress = await erc20SmartWallet.GetAddress();
 // Console.WriteLine($"ERC20 Smart Wallet address: {erc20SmartWalletAddress}");
 
-// var selfTransfer = await ThirdwebTransaction.Create(wallet: erc20SmartWallet, txInput: new ThirdwebTransactionInput(chainId: 1135, to: erc20SmartWalletAddress, value: 0, data: "0x"));
-
-// var receipt = await ThirdwebTransaction.SendAndWaitForTransactionReceipt(selfTransfer);
+// var receipt = await erc20SmartWallet.Transfer(chainId: chainId, toAddress: erc20SmartWalletAddress, weiAmount: 0);
 // Console.WriteLine($"Receipt: {JsonConvert.SerializeObject(receipt, Formatting.Indented)}");
 
 #endregion

--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -68,7 +68,7 @@ public class SmartWallet : IThirdwebWallet
                 new TokenPaymasterConfig()
                 {
                     ChainId = 8453,
-                    PaymasterAddress = "0x34d19b49Eae24Ce4334c25f61865aA0C78467cF3",
+                    PaymasterAddress = "0x2222f2738BE6bB7aA0Bfe4AEeAf2908172CF5539",
                     TokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
                     BalanceStorageSlot = 9
                 }
@@ -78,7 +78,7 @@ public class SmartWallet : IThirdwebWallet
                 new TokenPaymasterConfig()
                 {
                     ChainId = 42220,
-                    PaymasterAddress = "0xBD17517383512E5b9eEEB7320A1BCfde66B78ac5",
+                    PaymasterAddress = "0x3feA3c5744D715ff46e91C4e5C9a94426DfF2aF9",
                     TokenAddress = "0x765DE816845861e75A25fCA122bb6898B8B1282a",
                     BalanceStorageSlot = 9
                 }
@@ -88,7 +88,7 @@ public class SmartWallet : IThirdwebWallet
                 new TokenPaymasterConfig()
                 {
                     ChainId = 1135,
-                    PaymasterAddress = "0xD1D1408b198C151bbe66F34D84b404a6e94f816f",
+                    PaymasterAddress = "0x9eb8cf7fBa5ed9EeDCC97a0d52254cc0e9B1AC25",
                     TokenAddress = "0xac485391EB2d7D88253a7F1eF18C37f4242D1A24",
                     BalanceStorageSlot = 9
                 }
@@ -176,7 +176,7 @@ public class SmartWallet : IThirdwebWallet
             }
         }
 
-        entryPoint ??= Constants.ENTRYPOINT_ADDRESS_V06;
+        entryPoint ??= tokenPaymaster == TokenPaymaster.NONE ? Constants.ENTRYPOINT_ADDRESS_V06 : Constants.ENTRYPOINT_ADDRESS_V07;
 
         var entryPointVersion = Utils.GetEntryPointVersion(entryPoint);
 


### PR DESCRIPTION
Lisk LSK Paymaster
Base USDC Paymaster
Celo CUSD Paymaster

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on adding support for new token paymasters (`CELO_CUSD` and `LISK_LSK`) in the `SmartWallet` implementation, along with updating the `PaymasterAddress` for `BASE_USDC`. It also modifies some commented-out code to reflect these changes.

### Detailed summary
- Added support for `CELO_CUSD` and `LISK_LSK` token paymasters in `SmartWallet`.
- Updated `PaymasterAddress` for `BASE_USDC`.
- Changed logic for determining `entryPoint` based on `tokenPaymaster`.
- Adjusted `PaymasterPostOpGasLimit` calculation.
- Updated comments and code examples for `CELO_CUSD` and `LISK_LSK`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->