### PR TITLE
[Pay] Allow passing purchaseData with quotes

### DIFF
--- a/Thirdweb/Thirdweb.Pay/ThirdwebPay.GetBuyWithCryptoQuote.cs
+++ b/Thirdweb/Thirdweb.Pay/ThirdwebPay.GetBuyWithCryptoQuote.cs
@@ -16,30 +16,18 @@ public partial class ThirdwebPay
     /// <exception cref="Exception">Thrown if the HTTP response is not successful.</exception>
     public static async Task<BuyWithCryptoQuoteResult> GetBuyWithCryptoQuote(ThirdwebClient client, BuyWithCryptoQuoteParams buyWithCryptoParams)
     {
-        var queryString = new Dictionary<string, string>
-        {
-            { "fromAddress", buyWithCryptoParams.FromAddress },
-            { "fromChainId", buyWithCryptoParams.FromChainId?.ToString() },
-            { "fromTokenAddress", buyWithCryptoParams.FromTokenAddress },
-            { "fromAmount", buyWithCryptoParams.FromAmount },
-            { "fromAmountWei", buyWithCryptoParams.FromAmountWei },
-            { "toChainId", buyWithCryptoParams.ToChainId?.ToString() },
-            { "toTokenAddress", buyWithCryptoParams.ToTokenAddress },
-            { "toAmount", buyWithCryptoParams.ToAmount },
-            { "toAmountWei", buyWithCryptoParams.ToAmountWei },
-            { "toAddress", buyWithCryptoParams.ToAddress },
-            { "maxSlippageBPS", buyWithCryptoParams.MaxSlippageBPS?.ToString() },
-            { "intentId", buyWithCryptoParams.IntentId }
-        };
+        var response = await client.HttpClient.PostAsync(
+            THIRDWEB_PAY_CRYPTO_QUOTE_ENDPOINT,
+            new StringContent(
+                JsonConvert.SerializeObject(buyWithCryptoParams, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }),
+                System.Text.Encoding.UTF8,
+                "application/json"
+            )
+        );
 
-        var queryStringFormatted = string.Join("&", queryString.Where(kv => kv.Value != null).Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
-        var url = $"{THIRDWEB_PAY_CRYPTO_QUOTE_ENDPOINT}?{queryStringFormatted}";
+        var content = await response.Content.ReadAsStringAsync();
 
-        var getResponse = await client.HttpClient.GetAsync(url);
-
-        var content = await getResponse.Content.ReadAsStringAsync();
-
-        if (!getResponse.IsSuccessStatusCode)
+        if (!response.IsSuccessStatusCode)
         {
             ErrorResponse error;
             try
@@ -56,14 +44,12 @@ public partial class ThirdwebPay
                         Reason = "Unknown",
                         Code = "Unknown",
                         Stack = "Unknown",
-                        StatusCode = (int)getResponse.StatusCode
+                        StatusCode = (int)response.StatusCode
                     }
                 };
             }
 
-            throw new Exception(
-                $"HTTP error! Code: {error.Error.Code} Message: {error.Error.Message} Reason: {error.Error.Reason} StatusCode: {error.Error.StatusCode} Stack: {error.Error.Stack}"
-            );
+            throw new Exception($"HTTP error! Code: {error.Error.Code} Message: {error.Error.Message} Reason: {error.Error.Reason} StatusCode: {error.Error.StatusCode} Stack: {error.Error.Stack}");
         }
 
         var data = JsonConvert.DeserializeObject<GetSwapQuoteResponse>(content);

--- a/Thirdweb/Thirdweb.Pay/ThirdwebPay.GetBuyWithFiatQuote.cs
+++ b/Thirdweb/Thirdweb.Pay/ThirdwebPay.GetBuyWithFiatQuote.cs
@@ -16,29 +16,18 @@ public partial class ThirdwebPay
     /// <exception cref="Exception">Thrown if the HTTP response is not successful.</exception>
     public static async Task<BuyWithFiatQuoteResult> GetBuyWithFiatQuote(ThirdwebClient client, BuyWithFiatQuoteParams buyWithFiatParams)
     {
-        var queryString = new Dictionary<string, string>
-        {
-            { "fromCurrencySymbol", buyWithFiatParams.FromCurrencySymbol },
-            { "fromAmount", buyWithFiatParams.FromAmount },
-            { "fromAmountUnits", buyWithFiatParams.FromAmountUnits },
-            { "toAddress", buyWithFiatParams.ToAddress },
-            { "toChainId", buyWithFiatParams.ToChainId },
-            { "toTokenAddress", buyWithFiatParams.ToTokenAddress },
-            { "toAmount", buyWithFiatParams.ToAmount },
-            { "toAmountWei", buyWithFiatParams.ToAmountWei },
-            { "preferredProvider", buyWithFiatParams.PreferredProvider },
-            { "maxSlippageBPS", buyWithFiatParams.MaxSlippageBPS?.ToString() }
-        };
+        var response = await client.HttpClient.PostAsync(
+            THIRDWEB_PAY_FIAT_QUOTE_ENDPOINT,
+            new StringContent(
+                JsonConvert.SerializeObject(buyWithFiatParams, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }),
+                System.Text.Encoding.UTF8,
+                "application/json"
+            )
+        );
 
-        var queryStringFormatted = string.Join("&", queryString.Where(kv => kv.Value != null).Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
-        var url = $"{THIRDWEB_PAY_FIAT_QUOTE_ENDPOINT}?{queryStringFormatted}";
-        url += buyWithFiatParams.IsTestMode ? "&isTestMode=true" : "&isTestMode=false";
+        var content = await response.Content.ReadAsStringAsync();
 
-        var getResponse = await client.HttpClient.GetAsync(url);
-
-        var content = await getResponse.Content.ReadAsStringAsync();
-
-        if (!getResponse.IsSuccessStatusCode)
+        if (!response.IsSuccessStatusCode)
         {
             ErrorResponse error;
             try
@@ -55,14 +44,12 @@ public partial class ThirdwebPay
                         Reason = "Unknown",
                         Code = "Unknown",
                         Stack = "Unknown",
-                        StatusCode = (int)getResponse.StatusCode
+                        StatusCode = (int)response.StatusCode
                     }
                 };
             }
 
-            throw new Exception(
-                $"HTTP error! Code: {error.Error.Code} Message: {error.Error.Message} Reason: {error.Error.Reason} StatusCode: {error.Error.StatusCode} Stack: {error.Error.Stack}"
-            );
+            throw new Exception($"HTTP error! Code: {error.Error.Code} Message: {error.Error.Message} Reason: {error.Error.Reason} StatusCode: {error.Error.StatusCode} Stack: {error.Error.Stack}");
         }
 
         var data = JsonConvert.DeserializeObject<GetFiatQuoteResponse>(content);

--- a/Thirdweb/Thirdweb.Pay/Types.GetBuyWithCryptoQuote.cs
+++ b/Thirdweb/Thirdweb.Pay/Types.GetBuyWithCryptoQuote.cs
@@ -21,7 +21,8 @@ public class BuyWithCryptoQuoteParams(
     string toAmountWei = null,
     string toAddress = null,
     double? maxSlippageBPS = null,
-    string intentId = null
+    string intentId = null,
+    object purchaseData = null
     )
 {
     /// <summary>
@@ -95,6 +96,12 @@ public class BuyWithCryptoQuoteParams(
     /// </summary>
     [JsonProperty("intentId")]
     public string IntentId { get; set; } = intentId;
+
+    /// <summary>
+    /// Additional data for the purchase. Useful with direct transfer flow.
+    /// </summary>
+    [JsonProperty("purchaseData")]
+    public object PurchaseData { get; set; } = purchaseData;
 }
 
 /// <summary>

--- a/Thirdweb/Thirdweb.Pay/Types.GetBuyWithCryptoStatus.cs
+++ b/Thirdweb/Thirdweb.Pay/Types.GetBuyWithCryptoStatus.cs
@@ -78,6 +78,12 @@ public class BuyWithCryptoStatusResult
     /// </summary>
     [JsonProperty("bridge")]
     public string Bridge { get; set; }
+
+    /// <summary>
+    /// Additional data for the purchase. Useful with direct transfer flow.
+    /// </summary>
+    [JsonProperty("purchaseData")]
+    public object PurchaseData { get; set; }
 }
 
 /// <summary>

--- a/Thirdweb/Thirdweb.Pay/Types.GetBuyWithFiatQuote.cs
+++ b/Thirdweb/Thirdweb.Pay/Types.GetBuyWithFiatQuote.cs
@@ -19,7 +19,8 @@ public class BuyWithFiatQuoteParams(
     string toAmountWei = null,
     double? maxSlippageBPS = null,
     bool isTestMode = false,
-    string preferredProvider = null
+    string preferredProvider = null,
+    object purchaseData = null
     )
 {
     /// <summary>
@@ -40,11 +41,6 @@ public class BuyWithFiatQuoteParams(
     [JsonProperty("fromAmountUnits")]
     public string FromAmountUnits { get; set; } = fromAmountUnits;
 
-    /// <summary>
-    /// The provider to use on the application for thirdweb pay
-    /// </summary>
-    [JsonProperty("preferredProvider")]
-    public string PreferredProvider { get; set; } = preferredProvider;
     /// <summary>
     /// The address to receive the purchased tokens.
     /// </summary>
@@ -86,6 +82,18 @@ public class BuyWithFiatQuoteParams(
     /// </summary>
     [JsonProperty("isTestMode")]
     public bool IsTestMode { get; set; } = isTestMode;
+
+    /// <summary>
+    /// The provider to use on the application for thirdweb pay
+    /// </summary>
+    [JsonProperty("preferredProvider")]
+    public string PreferredProvider { get; set; } = preferredProvider;
+
+    /// <summary>
+    /// Additional data for the purchase. Useful with direct transfer flow.
+    /// </summary>
+    [JsonProperty("purchaseData")]
+    public object PurchaseData { get; set; } = purchaseData;
 }
 
 /// <summary>

--- a/Thirdweb/Thirdweb.Pay/Types.GetBuyWithFiatStatus.cs
+++ b/Thirdweb/Thirdweb.Pay/Types.GetBuyWithFiatStatus.cs
@@ -60,6 +60,12 @@ public class BuyWithFiatStatusResult
     /// </summary>
     [JsonProperty("failureMessage")]
     public string FailureMessage { get; set; }
+
+    /// <summary>
+    /// Additional data for the purchase. Useful with direct transfer flow.
+    /// </summary>
+    [JsonProperty("purchaseData")]
+    public object PurchaseData { get; set; }
 }
 
 /// <summary>

--- a/Thirdweb/Thirdweb.Utils/Utils.cs
+++ b/Thirdweb/Thirdweb.Utils/Utils.cs
@@ -306,7 +306,24 @@ public static partial class Utils
     /// <returns>True if it is a zkSync chain ID, otherwise false.</returns>
     public static async Task<bool> IsZkSync(ThirdwebClient client, BigInteger chainId)
     {
-        if (chainId.Equals(324) || chainId.Equals(300) || chainId.Equals(302) || chainId.Equals(11124) || chainId.Equals(4654) || chainId.Equals(333271) || chainId.Equals(37111))
+        if (
+            chainId.Equals(324)
+            || chainId.Equals(300)
+            || chainId.Equals(302)
+            || chainId.Equals(11124)
+            || chainId.Equals(282)
+            || chainId.Equals(388)
+            || chainId.Equals(4654)
+            || chainId.Equals(333271)
+            || chainId.Equals(37111)
+            || chainId.Equals(978658)
+            || chainId.Equals(531050104)
+            || chainId.Equals(4457845)
+            || chainId.Equals(2741)
+            || chainId.Equals(240)
+            || chainId.Equals(61166)
+            || chainId.Equals(555271)
+        )
         {
             return true;
         }


### PR DESCRIPTION
GET -> POST on quotes

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the `Thirdweb` payment types by adding a new property `PurchaseData` to several classes, which allows for additional data to be included in purchase transactions. It also improves the request handling in the `GetBuyWithFiatQuote` and `GetBuyWithCryptoQuote` methods.

### Detailed summary
- Added `PurchaseData` property to:
  - `Types.GetBuyWithCryptoStatus`
  - `Types.GetBuyWithFiatStatus`
  - `Types.GetBuyWithCryptoQuoteParams`
  - `Types.GetBuyWithFiatQuoteParams`
- Updated `GetBuyWithFiatQuote` and `GetBuyWithCryptoQuote` methods to use `POST` requests instead of `GET`.
- Enhanced error handling to use `response` status code instead of `getResponse`.
- Reformatted conditionals in `IsZkSync` for better readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->