### PR TITLE
[SmartWallet] Fix SwitchNetwork from zksync stack to non zksync

### DIFF
--- a/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.SmartWallet.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.SmartWallet.Tests.cs
@@ -314,41 +314,103 @@ public class SmartWalletTests : BaseTests
         Assert.True(hashes[1].TransactionHash.Length == 66);
     }
 
-    // [Fact(Timeout = 120000)]
-    // public async Task MultiChainTransaction_Success()
-    // {
-    //     var chainId1 = 11155111;
-    //     var chainId2 = 421614;
+    [Fact(Timeout = 120000)]
+    public async Task MultiChainTransaction_Success()
+    {
+        var chainId1 = 11155111;
+        var chainId2 = 421614;
 
-    //     var smartWallet = await SmartWallet.Create(
-    //         personalWallet: await PrivateKeyWallet.Generate(this.Client),
-    //         chainId: chainId1,
-    //         gasless: true,
-    //         factoryAddress: Constants.DEFAULT_FACTORY_ADDRESS_V06,
-    //         entryPoint: Constants.ENTRYPOINT_ADDRESS_V06
-    //     );
+        var smartWallet = await SmartWallet.Create(personalWallet: await PrivateKeyWallet.Generate(this.Client), chainId: chainId1, gasless: true);
 
-    //     var address1 = await smartWallet.GetAddress();
-    //     var receipt1 = await smartWallet.ExecuteTransaction(new ThirdwebTransactionInput(chainId1) { To = address1, });
-    //     var nonce1 = await smartWallet.GetTransactionCount(chainId: chainId1, blocktag: "latest");
+        var address1 = await smartWallet.GetAddress();
+        var receipt1 = await smartWallet.ExecuteTransaction(new ThirdwebTransactionInput(chainId1) { To = address1, });
+        var nonce1 = await smartWallet.GetTransactionCount(chainId: chainId1, blocktag: "latest");
 
-    //     var address2 = await smartWallet.GetAddress();
-    //     var receipt2 = await smartWallet.ExecuteTransaction(new ThirdwebTransactionInput(chainId2) { To = address2, });
-    //     var nonce2 = await smartWallet.GetTransactionCount(chainId: chainId2, blocktag: "latest");
+        var address2 = await smartWallet.GetAddress();
+        var receipt2 = await smartWallet.ExecuteTransaction(new ThirdwebTransactionInput(chainId2) { To = address2, });
+        var nonce2 = await smartWallet.GetTransactionCount(chainId: chainId2, blocktag: "latest");
 
-    //     Assert.NotNull(address1);
-    //     Assert.NotNull(address2);
-    //     Assert.Equal(address1, address2);
+        Assert.NotNull(address1);
+        Assert.NotNull(address2);
+        Assert.Equal(address1, address2);
 
-    //     Assert.NotNull(receipt1);
-    //     Assert.NotNull(receipt2);
+        Assert.NotNull(receipt1);
+        Assert.NotNull(receipt2);
 
-    //     Assert.True(receipt1.TransactionHash.Length == 66);
-    //     Assert.True(receipt2.TransactionHash.Length == 66);
+        Assert.True(receipt1.TransactionHash.Length == 66);
+        Assert.True(receipt2.TransactionHash.Length == 66);
 
-    //     Assert.Equal(receipt1.To, receipt2.To);
+        Assert.Equal(receipt1.To, receipt2.To);
 
-    //     Assert.Equal(nonce1, 1);
-    //     Assert.Equal(nonce2, 1);
-    // }
+        Assert.Equal(nonce1, 1);
+        Assert.Equal(nonce2, 1);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task MultiChainTransaction_ZkToNonZk_Success()
+    {
+        var chainId1 = 300;
+        var chainId2 = 421614;
+
+        var smartWallet = await SmartWallet.Create(personalWallet: await PrivateKeyWallet.Generate(this.Client), chainId: chainId1, gasless: true);
+
+        var randomAddy = await (await PrivateKeyWallet.Generate(this.Client)).GetAddress();
+
+        var receipt1 = await smartWallet.ExecuteTransaction(new ThirdwebTransactionInput(chainId1) { To = randomAddy, });
+        var nonce1 = await smartWallet.GetTransactionCount(chainId: chainId1, blocktag: "latest");
+        var address1 = await smartWallet.GetAddress();
+
+        var receipt2 = await smartWallet.ExecuteTransaction(new ThirdwebTransactionInput(chainId2) { To = randomAddy, });
+        var nonce2 = await smartWallet.GetTransactionCount(chainId: chainId2, blocktag: "latest");
+        var address2 = await smartWallet.GetAddress();
+
+        Assert.NotNull(address1);
+        Assert.NotNull(address2);
+        Assert.NotEqual(address1, address2);
+
+        Assert.NotNull(receipt1);
+        Assert.NotNull(receipt2);
+
+        Assert.True(receipt1.TransactionHash.Length == 66);
+        Assert.True(receipt2.TransactionHash.Length == 66);
+
+        Assert.NotEqual(receipt1.To, receipt2.To);
+
+        Assert.Equal(nonce1, 1);
+        Assert.Equal(nonce2, 1);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task MultiChainTransaction_NonZkToZk_Success()
+    {
+        var chainId1 = 421614;
+        var chainId2 = 300;
+
+        var smartWallet = await SmartWallet.Create(personalWallet: await PrivateKeyWallet.Generate(this.Client), chainId: chainId1, gasless: true);
+
+        var randomAddy = await (await PrivateKeyWallet.Generate(this.Client)).GetAddress();
+
+        var receipt1 = await smartWallet.ExecuteTransaction(new ThirdwebTransactionInput(chainId1) { To = randomAddy, });
+        var nonce1 = await smartWallet.GetTransactionCount(chainId: chainId1, blocktag: "latest");
+        var address1 = await smartWallet.GetAddress();
+
+        var receipt2 = await smartWallet.ExecuteTransaction(new ThirdwebTransactionInput(chainId2) { To = randomAddy, });
+        var nonce2 = await smartWallet.GetTransactionCount(chainId: chainId2, blocktag: "latest");
+        var address2 = await smartWallet.GetAddress();
+
+        Assert.NotNull(address1);
+        Assert.NotNull(address2);
+        Assert.NotEqual(address1, address2);
+
+        Assert.NotNull(receipt1);
+        Assert.NotNull(receipt2);
+
+        Assert.True(receipt1.TransactionHash.Length == 66);
+        Assert.True(receipt2.TransactionHash.Length == 66);
+
+        Assert.NotEqual(receipt1.To, receipt2.To);
+
+        Assert.Equal(nonce1, 1);
+        Assert.Equal(nonce2, 1);
+    }
 }

--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -185,19 +185,15 @@ public class SmartWallet : IThirdwebWallet
         paymasterUrl ??= $"https://{chainId}.bundler.thirdweb.com/v2";
         factoryAddress ??= entryPointVersion == 6 ? Constants.DEFAULT_FACTORY_ADDRESS_V06 : Constants.DEFAULT_FACTORY_ADDRESS_V07;
 
-        ThirdwebContract entryPointContract = null;
-        ThirdwebContract factoryContract = null;
-        ThirdwebContract accountContract = null;
+        var entryPointAbi = entryPointVersion == 6 ? Constants.ENTRYPOINT_V06_ABI : Constants.ENTRYPOINT_V07_ABI;
+        var factoryAbi = entryPointVersion == 6 ? Constants.FACTORY_V06_ABI : Constants.FACTORY_V07_ABI;
+        var entryPointContract = await ThirdwebContract.Create(personalWallet.Client, entryPoint, chainId, entryPointAbi).ConfigureAwait(false);
+        var factoryContract = await ThirdwebContract.Create(personalWallet.Client, factoryAddress, chainId, factoryAbi).ConfigureAwait(false);
 
+        ThirdwebContract accountContract = null;
         if (!await Utils.IsZkSync(personalWallet.Client, chainId).ConfigureAwait(false))
         {
-            var entryPointAbi = entryPointVersion == 6 ? Constants.ENTRYPOINT_V06_ABI : Constants.ENTRYPOINT_V07_ABI;
-            var factoryAbi = entryPointVersion == 6 ? Constants.FACTORY_V06_ABI : Constants.FACTORY_V07_ABI;
             var accountAbi = entryPointVersion == 6 ? Constants.ACCOUNT_V06_ABI : Constants.ACCOUNT_V07_ABI;
-
-            entryPointContract = await ThirdwebContract.Create(personalWallet.Client, entryPoint, chainId, entryPointAbi).ConfigureAwait(false);
-            factoryContract = await ThirdwebContract.Create(personalWallet.Client, factoryAddress, chainId, factoryAbi).ConfigureAwait(false);
-
             var personalAddress = await personalWallet.GetAddress().ConfigureAwait(false);
             var accountAddress = accountAddressOverride ?? await ThirdwebContract.Read<string>(factoryContract, "getAddress", personalAddress, Array.Empty<byte>()).ConfigureAwait(false);
 
@@ -263,7 +259,6 @@ public class SmartWallet : IThirdwebWallet
             throw new InvalidOperationException("You cannot switch networks when using an ERC20 paymaster yet.");
         }
 
-        this._chainId = chainId;
         this._bundlerUrl = this._bundlerUrl.Contains(".thirdweb.com") ? $"https://{chainId}.bundler.thirdweb.com/v2" : this._bundlerUrl;
         this._paymasterUrl = this._paymasterUrl.Contains(".thirdweb.com") ? $"https://{chainId}.bundler.thirdweb.com/v2" : this._paymasterUrl;
 
@@ -271,8 +266,13 @@ public class SmartWallet : IThirdwebWallet
         {
             this._entryPointContract = await ThirdwebContract.Create(this.Client, this._entryPointContract.Address, chainId, this._entryPointContract.Abi).ConfigureAwait(false);
             this._factoryContract = await ThirdwebContract.Create(this.Client, this._factoryContract.Address, chainId, this._factoryContract.Abi).ConfigureAwait(false);
-            this._accountContract = await ThirdwebContract.Create(this.Client, this._accountContract.Address, chainId, this._accountContract.Abi).ConfigureAwait(false);
+
+            var personalAddress = await this._personalAccount.GetAddress().ConfigureAwait(false);
+            var accountAddress = await ThirdwebContract.Read<string>(this._factoryContract, "getAddress", personalAddress, Array.Empty<byte>()).ConfigureAwait(false);
+            this._accountContract = await ThirdwebContract.Create(this._personalAccount.Client, accountAddress, chainId, Constants.ACCOUNT_V06_ABI).ConfigureAwait(false);
         }
+
+        this._chainId = chainId;
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `SmartWallet` functionality by improving contract initialization based on the entry point version and adding new test cases for multi-chain transactions.

### Detailed summary
- Refactored contract initialization in `SmartWallet.cs` to use `var` for `entryPointAbi` and `factoryAbi`.
- Removed redundant contract creation calls.
- Added new test cases in `Thirdweb.SmartWallet.Tests.cs` for:
  - Multi-chain transaction success.
  - Multi-chain transaction from zk to non-zk.
  - Multi-chain transaction from non-zk to zk.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->