### PR TITLE
Account Unlinking

### DIFF
--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -260,24 +260,16 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 // var oldLinkedAccounts = await inAppWalletMain.GetLinkedAccounts();
 // Console.WriteLine($"Old linked accounts: {JsonConvert.SerializeObject(oldLinkedAccounts, Formatting.Indented)}");
 
-// External wallet variant
+// // External wallet variant
 // var externalWallet = await PrivateKeyWallet.Generate(client: client);
 // var externalWalletAddress = await externalWallet.GetAddress();
 // var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Siwe, siweSigner: externalWallet);
 // _ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, chainId: 421614);
 
-// Email variant
-// var linkedEmail = "firekeeper+unlinkingtest@thirdweb.com";
-// var inAppWalletToLink = await InAppWallet.Create(client: client, email: linkedEmail);
-// await inAppWalletToLink.SendOTP();
-// Console.WriteLine("Enter OTP:");
-// var otp = Console.ReadLine();
-// _ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, otp: otp);
-
 // var linkedAccounts = await inAppWalletMain.GetLinkedAccounts();
 // Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
 
-// var unlinkingResult = await inAppWalletMain.UnlinkAccount(authProviderToUnlink: UnlinkingType.email, email: linkedEmail);
+// var unlinkingResult = await inAppWalletMain.UnlinkAccount(linkedType: "siwe", address: externalWalletAddress);
 // Console.WriteLine($"Unlinking result: {JsonConvert.SerializeObject(unlinkingResult, Formatting.Indented)}");
 
 #endregion

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -241,34 +241,33 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 
 #region Account Linking
 
-var inAppWalletMain = await InAppWallet.Create(client: client, authProvider: AuthProvider.Telegram);
-if (!await inAppWalletMain.IsConnected())
-{
-    _ = await inAppWalletMain.LoginWithOauth(
-        isMobile: false,
-        (url) =>
-        {
-            var psi = new ProcessStartInfo { FileName = url, UseShellExecute = true };
-            _ = Process.Start(psi);
-        },
-        "thirdweb://",
-        new InAppWalletBrowser()
-    );
-}
-Console.WriteLine($"Main InAppWallet address: {await inAppWalletMain.GetAddress()}");
+// var inAppWalletMain = await InAppWallet.Create(client: client, authProvider: AuthProvider.Telegram);
+// if (!await inAppWalletMain.IsConnected())
+// {
+//     _ = await inAppWalletMain.LoginWithOauth(
+//         isMobile: false,
+//         (url) =>
+//         {
+//             var psi = new ProcessStartInfo { FileName = url, UseShellExecute = true };
+//             _ = Process.Start(psi);
+//         },
+//         "thirdweb://",
+//         new InAppWalletBrowser()
+//     );
+// }
+// Console.WriteLine($"Main InAppWallet address: {await inAppWalletMain.GetAddress()}");
 
-var oldLinkedAccounts = await inAppWalletMain.GetLinkedAccounts();
-Console.WriteLine($"Old linked accounts: {JsonConvert.SerializeObject(oldLinkedAccounts, Formatting.Indented)}");
+// var oldLinkedAccounts = await inAppWalletMain.GetLinkedAccounts();
+// Console.WriteLine($"Old linked accounts: {JsonConvert.SerializeObject(oldLinkedAccounts, Formatting.Indented)}");
 
-// External wallet variant
-var externalWallet = await PrivateKeyWallet.Generate(client: client);
-var externalWalletAddress = await externalWallet.GetAddress();
-var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Siwe, siweSigner: externalWallet);
-var linkedAccounts = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, chainId: 421614);
-Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
+// // External wallet variant
+// var externalWallet = await PrivateKeyWallet.Generate(client: client);
+// var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Siwe, siweSigner: externalWallet);
+// var linkedAccounts = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, chainId: 421614);
+// Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
 
-var unlinkingResult = await inAppWalletMain.UnlinkAccount(linkedAccounts.First(linkedAccounts => linkedAccounts.Type == "siwe"));
-Console.WriteLine($"Unlinking result: {JsonConvert.SerializeObject(unlinkingResult, Formatting.Indented)}");
+// var unlinkingResult = await inAppWalletMain.UnlinkAccount(linkedAccounts.First(linkedAccounts => linkedAccounts.Type == "siwe"));
+// Console.WriteLine($"Unlinking result: {JsonConvert.SerializeObject(unlinkingResult, Formatting.Indented)}");
 
 #endregion
 

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -241,36 +241,34 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 
 #region Account Linking
 
-// var inAppWalletMain = await InAppWallet.Create(client: client, authProvider: AuthProvider.Telegram);
-// if (!await inAppWalletMain.IsConnected())
-// {
-//     _ = await inAppWalletMain.LoginWithOauth(
-//         isMobile: false,
-//         (url) =>
-//         {
-//             var psi = new ProcessStartInfo { FileName = url, UseShellExecute = true };
-//             _ = Process.Start(psi);
-//         },
-//         "thirdweb://",
-//         new InAppWalletBrowser()
-//     );
-// }
-// Console.WriteLine($"Main InAppWallet address: {await inAppWalletMain.GetAddress()}");
+var inAppWalletMain = await InAppWallet.Create(client: client, authProvider: AuthProvider.Telegram);
+if (!await inAppWalletMain.IsConnected())
+{
+    _ = await inAppWalletMain.LoginWithOauth(
+        isMobile: false,
+        (url) =>
+        {
+            var psi = new ProcessStartInfo { FileName = url, UseShellExecute = true };
+            _ = Process.Start(psi);
+        },
+        "thirdweb://",
+        new InAppWalletBrowser()
+    );
+}
+Console.WriteLine($"Main InAppWallet address: {await inAppWalletMain.GetAddress()}");
 
-// var oldLinkedAccounts = await inAppWalletMain.GetLinkedAccounts();
-// Console.WriteLine($"Old linked accounts: {JsonConvert.SerializeObject(oldLinkedAccounts, Formatting.Indented)}");
+var oldLinkedAccounts = await inAppWalletMain.GetLinkedAccounts();
+Console.WriteLine($"Old linked accounts: {JsonConvert.SerializeObject(oldLinkedAccounts, Formatting.Indented)}");
 
-// // External wallet variant
-// var externalWallet = await PrivateKeyWallet.Generate(client: client);
-// var externalWalletAddress = await externalWallet.GetAddress();
-// var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Siwe, siweSigner: externalWallet);
-// _ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, chainId: 421614);
+// External wallet variant
+var externalWallet = await PrivateKeyWallet.Generate(client: client);
+var externalWalletAddress = await externalWallet.GetAddress();
+var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Siwe, siweSigner: externalWallet);
+var linkedAccounts = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, chainId: 421614);
+Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
 
-// var linkedAccounts = await inAppWalletMain.GetLinkedAccounts();
-// Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
-
-// var unlinkingResult = await inAppWalletMain.UnlinkAccount(linkedType: "siwe", address: externalWalletAddress);
-// Console.WriteLine($"Unlinking result: {JsonConvert.SerializeObject(unlinkingResult, Formatting.Indented)}");
+var unlinkingResult = await inAppWalletMain.UnlinkAccount(linkedAccounts.First(linkedAccounts => linkedAccounts.Type == "siwe"));
+Console.WriteLine($"Unlinking result: {JsonConvert.SerializeObject(unlinkingResult, Formatting.Indented)}");
 
 #endregion
 

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -241,7 +241,7 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 
 #region Account Linking
 
-// var inAppWalletMain = await InAppWallet.Create(client: client, authProvider: AuthProvider.Google);
+// var inAppWalletMain = await InAppWallet.Create(client: client, authProvider: AuthProvider.Telegram);
 // if (!await inAppWalletMain.IsConnected())
 // {
 //     _ = await inAppWalletMain.LoginWithOauth(
@@ -260,11 +260,25 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 // var oldLinkedAccounts = await inAppWalletMain.GetLinkedAccounts();
 // Console.WriteLine($"Old linked accounts: {JsonConvert.SerializeObject(oldLinkedAccounts, Formatting.Indented)}");
 
-// var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Guest);
-// _ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink);
+// External wallet variant
+// var externalWallet = await PrivateKeyWallet.Generate(client: client);
+// var externalWalletAddress = await externalWallet.GetAddress();
+// var inAppWalletToLink = await InAppWallet.Create(client: client, authProvider: AuthProvider.Siwe, siweSigner: externalWallet);
+// _ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, chainId: 421614);
+
+// Email variant
+// var linkedEmail = "firekeeper+unlinkingtest@thirdweb.com";
+// var inAppWalletToLink = await InAppWallet.Create(client: client, email: linkedEmail);
+// await inAppWalletToLink.SendOTP();
+// Console.WriteLine("Enter OTP:");
+// var otp = Console.ReadLine();
+// _ = await inAppWalletMain.LinkAccount(walletToLink: inAppWalletToLink, otp: otp);
 
 // var linkedAccounts = await inAppWalletMain.GetLinkedAccounts();
 // Console.WriteLine($"Linked accounts: {JsonConvert.SerializeObject(linkedAccounts, Formatting.Indented)}");
+
+// var unlinkingResult = await inAppWalletMain.UnlinkAccount(authProviderToUnlink: UnlinkingType.email, email: linkedEmail);
+// Console.WriteLine($"Unlinking result: {JsonConvert.SerializeObject(unlinkingResult, Formatting.Indented)}");
 
 #endregion
 

--- a/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
@@ -156,6 +156,16 @@ public interface IThirdwebWallet
     );
 
     /// <summary>
+    /// Unlinks an account (auth method) from the current wallet. Must pass corresponding parameter to unlink.
+    /// </summary>
+    /// <param name="authProviderToUnlink">The auth provider to unlink.</param>
+    /// <param name="address">The related wallet address to unlink (if applicable).</param>
+    /// <param name="email">The related email to unlink (if applicable).</param>
+    /// <param name="phone">The related phone number to unlink (if applicable).</param>
+    /// <param name="id">The related user ID to unlink (if applicable).</param>
+    Task<List<LinkedAccount>> UnlinkAccount(UnlinkingType authProviderToUnlink, string address = null, string email = null, string phone = null, string id = null);
+
+    /// <summary>
     /// Returns a list of linked accounts to the current wallet.
     /// </summary>
     /// <returns>A list of <see cref="LinkedAccount"/> objects.</returns>

--- a/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
@@ -156,14 +156,10 @@ public interface IThirdwebWallet
     );
 
     /// <summary>
-    /// Unlinks an account (auth method) from the current wallet. Must pass corresponding parameter to unlink.
+    /// Unlinks an account (auth method) from the current wallet.
     /// </summary>
-    /// <param name="linkedType">The auth provider to unlink, use the type you get from GetLinkedAccounts.</param>
-    /// <param name="address">The related wallet address to unlink (if applicable).</param>
-    /// <param name="email">The related email to unlink (if applicable).</param>
-    /// <param name="phone">The related phone number to unlink (if applicable).</param>
-    /// <param name="id">The related user ID to unlink (if applicable).</param>
-    Task<List<LinkedAccount>> UnlinkAccount(string linkedType, string address = null, string email = null, string phone = null, string id = null);
+    /// <param name="accountToUnlink">The linked account to unlink. Same type returned by <see cref="GetLinkedAccounts"/>.</param>
+    Task<List<LinkedAccount>> UnlinkAccount(LinkedAccount accountToUnlink);
 
     /// <summary>
     /// Returns a list of linked accounts to the current wallet.

--- a/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
@@ -158,12 +158,12 @@ public interface IThirdwebWallet
     /// <summary>
     /// Unlinks an account (auth method) from the current wallet. Must pass corresponding parameter to unlink.
     /// </summary>
-    /// <param name="authProviderToUnlink">The auth provider to unlink.</param>
+    /// <param name="linkedType">The auth provider to unlink, use the type you get from GetLinkedAccounts.</param>
     /// <param name="address">The related wallet address to unlink (if applicable).</param>
     /// <param name="email">The related email to unlink (if applicable).</param>
     /// <param name="phone">The related phone number to unlink (if applicable).</param>
     /// <param name="id">The related user ID to unlink (if applicable).</param>
-    Task<List<LinkedAccount>> UnlinkAccount(UnlinkingType authProviderToUnlink, string address = null, string email = null, string phone = null, string id = null);
+    Task<List<LinkedAccount>> UnlinkAccount(string linkedType, string address = null, string email = null, string phone = null, string id = null);
 
     /// <summary>
     /// Returns a list of linked accounts to the current wallet.

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
@@ -332,7 +332,7 @@ public partial class EcosystemWallet : IThirdwebWallet
 
     #region Account Linking
 
-    public async Task<List<LinkedAccount>> UnlinkAccount(UnlinkingType authProviderToUnlink, string address = null, string email = null, string phone = null, string id = null)
+    public async Task<List<LinkedAccount>> UnlinkAccount(string linkedType, string address = null, string email = null, string phone = null, string id = null)
     {
         if (!await this.IsConnected().ConfigureAwait(false))
         {
@@ -340,7 +340,6 @@ public partial class EcosystemWallet : IThirdwebWallet
         }
 
         var currentAccountToken = this.EmbeddedWallet.GetSessionData()?.AuthToken;
-        var linkedType = authProviderToUnlink.ToString();
         var linkedDetails = new
         {
             address,

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
@@ -332,7 +332,7 @@ public partial class EcosystemWallet : IThirdwebWallet
 
     #region Account Linking
 
-    public async Task<List<LinkedAccount>> UnlinkAccount(string linkedType, string address = null, string email = null, string phone = null, string id = null)
+    public async Task<List<LinkedAccount>> UnlinkAccount(LinkedAccount accountToUnlink)
     {
         if (!await this.IsConnected().ConfigureAwait(false))
         {
@@ -340,15 +340,8 @@ public partial class EcosystemWallet : IThirdwebWallet
         }
 
         var currentAccountToken = this.EmbeddedWallet.GetSessionData()?.AuthToken;
-        var linkedDetails = new
-        {
-            address,
-            email,
-            phone,
-            id
-        };
 
-        var serverLinkedAccounts = await this.EmbeddedWallet.UnlinkAccountAsync(currentAccountToken, linkedType, linkedDetails).ConfigureAwait(false);
+        var serverLinkedAccounts = await this.EmbeddedWallet.UnlinkAccountAsync(currentAccountToken, accountToUnlink).ConfigureAwait(false);
         var linkedAccounts = new List<LinkedAccount>();
         foreach (var linkedAccount in serverLinkedAccounts)
         {

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
@@ -332,6 +332,44 @@ public partial class EcosystemWallet : IThirdwebWallet
 
     #region Account Linking
 
+    public async Task<List<LinkedAccount>> UnlinkAccount(UnlinkingType authProviderToUnlink, string address = null, string email = null, string phone = null, string id = null)
+    {
+        if (!await this.IsConnected().ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("Cannot unlink account with a wallet that is not connected. Please login to the wallet before unlinking other wallets.");
+        }
+
+        var currentAccountToken = this.EmbeddedWallet.GetSessionData()?.AuthToken;
+        var linkedType = authProviderToUnlink.ToString();
+        var linkedDetails = new
+        {
+            address,
+            email,
+            phone,
+            id
+        };
+
+        var serverLinkedAccounts = await this.EmbeddedWallet.UnlinkAccountAsync(currentAccountToken, linkedType, linkedDetails).ConfigureAwait(false);
+        var linkedAccounts = new List<LinkedAccount>();
+        foreach (var linkedAccount in serverLinkedAccounts)
+        {
+            linkedAccounts.Add(
+                new LinkedAccount
+                {
+                    Type = linkedAccount.Type,
+                    Details = new LinkedAccount.LinkedAccountDetails
+                    {
+                        Email = linkedAccount.Details?.Email,
+                        Address = linkedAccount.Details?.Address,
+                        Phone = linkedAccount.Details?.Phone,
+                        Id = linkedAccount.Details?.Id
+                    }
+                }
+            );
+        }
+        return linkedAccounts;
+    }
+
     public async Task<List<LinkedAccount>> LinkAccount(
         IThirdwebWallet walletToLink,
         string otp = null,

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet.Authentication/Server.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet.Authentication/Server.cs
@@ -6,7 +6,7 @@ namespace Thirdweb.EWS;
 
 internal abstract class ServerBase
 {
-    internal abstract Task<List<Server.LinkedAccount>> UnlinkAccountAsync(string currentAccountToken, string linkedType, object linkedDetails);
+    internal abstract Task<List<Server.LinkedAccount>> UnlinkAccountAsync(string currentAccountToken, Server.LinkedAccount linkedAccount);
     internal abstract Task<List<Server.LinkedAccount>> LinkAccountAsync(string currentAccountToken, string authTokenToConnect);
     internal abstract Task<List<Server.LinkedAccount>> GetLinkedAccountsAsync(string currentAccountToken);
 
@@ -52,12 +52,12 @@ internal partial class Server : ServerBase
     }
 
     // account/disconnect
-    internal override async Task<List<LinkedAccount>> UnlinkAccountAsync(string currentAccountToken, string linkedType, object linkedDetails)
+    internal override async Task<List<LinkedAccount>> UnlinkAccountAsync(string currentAccountToken, LinkedAccount linkedAccount)
     {
         var uri = MakeUri2024("/account/disconnect");
         var request = new HttpRequestMessage(HttpMethod.Post, uri)
         {
-            Content = MakeHttpContent(new { type = linkedType, details = linkedDetails })
+            Content = MakeHttpContent(linkedAccount)
         };
         var response = await this.SendHttpWithAuthAsync(request, currentAccountToken).ConfigureAwait(false);
         await CheckStatusCodeAsync(response).ConfigureAwait(false);

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet.Authentication/Server.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet.Authentication/Server.cs
@@ -6,6 +6,7 @@ namespace Thirdweb.EWS;
 
 internal abstract class ServerBase
 {
+    internal abstract Task<List<Server.LinkedAccount>> UnlinkAccountAsync(string currentAccountToken, string linkedType, object linkedDetails);
     internal abstract Task<List<Server.LinkedAccount>> LinkAccountAsync(string currentAccountToken, string authTokenToConnect);
     internal abstract Task<List<Server.LinkedAccount>> GetLinkedAccountsAsync(string currentAccountToken);
 
@@ -48,6 +49,21 @@ internal partial class Server : ServerBase
     {
         this._clientId = client.ClientId;
         this._httpClient = httpClient;
+    }
+
+    // account/disconnect
+    internal override async Task<List<LinkedAccount>> UnlinkAccountAsync(string currentAccountToken, string linkedType, object linkedDetails)
+    {
+        var uri = MakeUri2024("/account/disconnect");
+        var request = new HttpRequestMessage(HttpMethod.Post, uri)
+        {
+            Content = MakeHttpContent(new { type = linkedType, details = linkedDetails })
+        };
+        var response = await this.SendHttpWithAuthAsync(request, currentAccountToken).ConfigureAwait(false);
+        await CheckStatusCodeAsync(response).ConfigureAwait(false);
+
+        var res = await DeserializeAsync<AccountConnectResponse>(response).ConfigureAwait(false);
+        return res == null || res.LinkedAccounts == null || res.LinkedAccounts.Count == 0 ? throw new InvalidOperationException("No linked accounts returned") : res.LinkedAccounts;
     }
 
     // account/connect

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.AccountLinking.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.AccountLinking.cs
@@ -2,6 +2,11 @@
 
 internal partial class EmbeddedWallet
 {
+    public async Task<List<Server.LinkedAccount>> UnlinkAccountAsync(string currentAccountToken, string linkedType, object linkedDetails)
+    {
+        return await this._server.UnlinkAccountAsync(currentAccountToken, linkedType, linkedDetails).ConfigureAwait(false);
+    }
+
     public async Task<List<Server.LinkedAccount>> LinkAccountAsync(string currentAccountToken, string authTokenToConnect)
     {
         return await this._server.LinkAccountAsync(currentAccountToken, authTokenToConnect).ConfigureAwait(false);

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.AccountLinking.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet/EmbeddedWallet.AccountLinking.cs
@@ -2,9 +2,20 @@
 
 internal partial class EmbeddedWallet
 {
-    public async Task<List<Server.LinkedAccount>> UnlinkAccountAsync(string currentAccountToken, string linkedType, object linkedDetails)
+    public async Task<List<Server.LinkedAccount>> UnlinkAccountAsync(string currentAccountToken, LinkedAccount linkedAccount)
     {
-        return await this._server.UnlinkAccountAsync(currentAccountToken, linkedType, linkedDetails).ConfigureAwait(false);
+        var serverLinkedAccount = new Server.LinkedAccount
+        {
+            Type = linkedAccount.Type,
+            Details = new Server.LinkedAccount.LinkedAccountDetails
+            {
+                Email = linkedAccount.Details.Email,
+                Address = linkedAccount.Details.Address,
+                Phone = linkedAccount.Details.Phone,
+                Id = linkedAccount.Details.Id
+            }
+        };
+        return await this._server.UnlinkAccountAsync(currentAccountToken, serverLinkedAccount).ConfigureAwait(false);
     }
 
     public async Task<List<Server.LinkedAccount>> LinkAccountAsync(string currentAccountToken, string authTokenToConnect)

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.Types.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.Types.cs
@@ -31,14 +31,24 @@ public enum AuthProvider
 /// </summary>
 public struct LinkedAccount
 {
+    [JsonProperty("type")]
     public string Type { get; set; }
+
+    [JsonProperty("details")]
     public LinkedAccountDetails Details { get; set; }
 
     public struct LinkedAccountDetails
     {
+        [JsonProperty("email")]
         public string Email { get; set; }
+
+        [JsonProperty("name")]
         public string Address { get; set; }
+
+        [JsonProperty("phone")]
         public string Phone { get; set; }
+
+        [JsonProperty("id")]
         public string Id { get; set; }
     }
 

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.Types.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.Types.cs
@@ -26,28 +26,6 @@ public enum AuthProvider
     Steam
 }
 
-public enum UnlinkingType
-{
-    apple,
-    coinbase,
-    discord,
-    email,
-    facebook,
-    farcaster,
-    github,
-    google,
-    guest,
-    line,
-    passkey,
-    phone,
-    siwe,
-    steam,
-    telegram,
-    twitch,
-    x,
-    wallet
-}
-
 /// <summary>
 /// Represents a linked account.
 /// </summary>

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.Types.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.Types.cs
@@ -26,6 +26,28 @@ public enum AuthProvider
     Steam
 }
 
+public enum UnlinkingType
+{
+    apple,
+    coinbase,
+    discord,
+    email,
+    facebook,
+    farcaster,
+    github,
+    google,
+    guest,
+    line,
+    passkey,
+    phone,
+    siwe,
+    steam,
+    telegram,
+    twitch,
+    x,
+    wallet
+}
+
 /// <summary>
 /// Represents a linked account.
 /// </summary>

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -380,7 +380,7 @@ public class PrivateKeyWallet : IThirdwebWallet
         throw new InvalidOperationException("GetLinkedAccounts is not supported for private key wallets.");
     }
 
-    public Task<List<LinkedAccount>> UnlinkAccount(string linkedType, string address = null, string email = null, string phone = null, string id = null)
+    public Task<List<LinkedAccount>> UnlinkAccount(LinkedAccount accountToUnlink)
     {
         throw new InvalidOperationException("UnlinkAccount is not supported for private key wallets.");
     }

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -380,7 +380,7 @@ public class PrivateKeyWallet : IThirdwebWallet
         throw new InvalidOperationException("GetLinkedAccounts is not supported for private key wallets.");
     }
 
-    public Task<List<LinkedAccount>> UnlinkAccount(UnlinkingType authProviderToUnlink, string address = null, string email = null, string phone = null, string id = null)
+    public Task<List<LinkedAccount>> UnlinkAccount(string linkedType, string address = null, string email = null, string phone = null, string id = null)
     {
         throw new InvalidOperationException("UnlinkAccount is not supported for private key wallets.");
     }

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -380,5 +380,10 @@ public class PrivateKeyWallet : IThirdwebWallet
         throw new InvalidOperationException("GetLinkedAccounts is not supported for private key wallets.");
     }
 
+    public Task<List<LinkedAccount>> UnlinkAccount(UnlinkingType authProviderToUnlink, string address = null, string email = null, string phone = null, string id = null)
+    {
+        throw new InvalidOperationException("UnlinkAccount is not supported for private key wallets.");
+    }
+
     #endregion
 }

--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -1167,6 +1167,16 @@ public class SmartWallet : IThirdwebWallet
         return Task.CompletedTask;
     }
 
+    public async Task<List<LinkedAccount>> UnlinkAccount(UnlinkingType authProviderToUnlink, string address = null, string email = null, string phone = null, string id = null)
+    {
+        var personalWallet = await this.GetPersonalWallet().ConfigureAwait(false);
+        if (personalWallet is not InAppWallet and not EcosystemWallet)
+        {
+            throw new Exception("SmartWallet.UnlinkAccount is only supported if the signer is an InAppWallet or EcosystemWallet");
+        }
+        return await personalWallet.UnlinkAccount(authProviderToUnlink, address, email, phone, id).ConfigureAwait(false);
+    }
+
     public async Task<List<LinkedAccount>> LinkAccount(
         IThirdwebWallet walletToLink,
         string otp = null,

--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -1167,14 +1167,14 @@ public class SmartWallet : IThirdwebWallet
         return Task.CompletedTask;
     }
 
-    public async Task<List<LinkedAccount>> UnlinkAccount(string linkedType, string address = null, string email = null, string phone = null, string id = null)
+    public async Task<List<LinkedAccount>> UnlinkAccount(LinkedAccount accountToUnlink)
     {
         var personalWallet = await this.GetPersonalWallet().ConfigureAwait(false);
         if (personalWallet is not InAppWallet and not EcosystemWallet)
         {
             throw new Exception("SmartWallet.UnlinkAccount is only supported if the signer is an InAppWallet or EcosystemWallet");
         }
-        return await personalWallet.UnlinkAccount(linkedType, address, email, phone, id).ConfigureAwait(false);
+        return await personalWallet.UnlinkAccount(accountToUnlink).ConfigureAwait(false);
     }
 
     public async Task<List<LinkedAccount>> LinkAccount(

--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -1167,14 +1167,14 @@ public class SmartWallet : IThirdwebWallet
         return Task.CompletedTask;
     }
 
-    public async Task<List<LinkedAccount>> UnlinkAccount(UnlinkingType authProviderToUnlink, string address = null, string email = null, string phone = null, string id = null)
+    public async Task<List<LinkedAccount>> UnlinkAccount(string linkedType, string address = null, string email = null, string phone = null, string id = null)
     {
         var personalWallet = await this.GetPersonalWallet().ConfigureAwait(false);
         if (personalWallet is not InAppWallet and not EcosystemWallet)
         {
             throw new Exception("SmartWallet.UnlinkAccount is only supported if the signer is an InAppWallet or EcosystemWallet");
         }
-        return await personalWallet.UnlinkAccount(authProviderToUnlink, address, email, phone, id).ConfigureAwait(false);
+        return await personalWallet.UnlinkAccount(linkedType, address, email, phone, id).ConfigureAwait(false);
     }
 
     public async Task<List<LinkedAccount>> LinkAccount(


### PR DESCRIPTION
Closes CNCT-2627

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing the `UnlinkAccount` functionality across various wallet classes, enhancing the account management capabilities of the `Thirdweb` wallet system.

### Detailed summary
- Added `UnlinkAccount` method to `PrivateKeyWallet` with an exception message.
- Defined `UnlinkAccount` in `IThirdwebWallet` interface with XML documentation.
- Updated `LinkedAccount` struct in `InAppWallet.Types.cs` to include JSON properties.
- Implemented `UnlinkAccount` in `SmartWallet`, checking for wallet types.
- Added `UnlinkAccountAsync` in `EmbeddedWallet` for server-side unlinking.
- Implemented `UnlinkAccount` in `EcosystemWallet`, ensuring the wallet is connected.
- Enhanced `ServerBase` with `UnlinkAccountAsync` method for server interaction.
- Updated commented-out code in `Program.cs` to demonstrate unlinking functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->