### PR TITLE
EIP-7702 Integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: run
+
+run:
+	dotnet run --project Thirdweb.Console

--- a/Thirdweb.Console/Program.Types.cs
+++ b/Thirdweb.Console/Program.Types.cs
@@ -1,0 +1,16 @@
+﻿using System.Numerics;
+using Nethereum.ABI.FunctionEncoding.Attributes;
+
+namespace Thirdweb.Console;
+
+public class Call
+{
+    [Parameter("bytes", "data", 1)]
+    public required byte[] Data { get; set; }
+
+    [Parameter("address", "to", 2)]
+    public required string To { get; set; }
+
+    [Parameter("uint256", "value", 3)]
+    public required BigInteger Value { get; set; }
+}

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -18,20 +18,94 @@ var secretKey = Environment.GetEnvironmentVariable("THIRDWEB_SECRET_KEY");
 // Do not use private keys client side, use InAppWallet/SmartWallet instead
 var privateKey = Environment.GetEnvironmentVariable("PRIVATE_KEY");
 
-// Fetch timeout options are optional, default is 120000ms
-var client = ThirdwebClient.Create(secretKey: secretKey, fetchTimeoutOptions: new TimeoutOptions(storage: 120000, rpc: 120000, other: 120000));
+// Initialize client
+var client = ThirdwebClient.Create(secretKey: secretKey);
 
-// Create a private key wallet
-var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
+// Chain and contract addresses
+var chainWith7702 = 7078815900;
+var erc20ContractAddress = "0x852e8247A55C49dc3b7e6f8788347813e562F597"; // Mekong Token
+var delegationContractAddress = "0x7B9E7AFd452666302352D82161B083dF792f7Cf4"; // BatchCallDelegation
 
-// var walletAddress = await privateKeyWallet.GetAddress();
-// Console.WriteLine($"PK Wallet address: {walletAddress}");
+// Initialize contracts normally
+var erc20Contract = await ThirdwebContract.Create(client: client, address: erc20ContractAddress, chain: chainWith7702);
+var delegationContract = await ThirdwebContract.Create(
+    client: client,
+    address: delegationContractAddress,
+    chain: chainWith7702,
+    abi: /*lang=json,strict*/
+    "[{\"anonymous\": false,\"inputs\": [{\"indexed\": true,\"internalType\": \"address\",\"name\": \"to\",\"type\": \"address\"},{\"indexed\": false,\"internalType\": \"uint256\",\"name\": \"value\",\"type\": \"uint256\"},{\"indexed\": false,\"internalType\": \"bytes\",\"name\": \"data\",\"type\": \"bytes\"}],\"name\": \"Executed\",\"type\": \"event\"},{\"inputs\": [{\"components\": [{\"internalType\": \"bytes\",\"name\": \"data\",\"type\": \"bytes\"},{\"internalType\": \"address\",\"name\": \"to\",\"type\": \"address\"},{\"internalType\": \"uint256\",\"name\": \"value\",\"type\": \"uint256\"}],\"internalType\": \"struct BatchCallDelegation.Call[]\",\"name\": \"calls\",\"type\": \"tuple[]\"}],\"name\": \"execute\",\"outputs\": [],\"stateMutability\": \"payable\",\"type\": \"function\"}]"
+);
+
+// Initialize a 7702 EOA
+var eoaWallet = await PrivateKeyWallet.Generate(client);
+var eoaWalletAddress = await eoaWallet.GetAddress();
+Console.WriteLine($"EOA address: {eoaWalletAddress}");
+
+// Temporary - fund eoa wallet
+var fundingWallet = await PrivateKeyWallet.Create(client, privateKey);
+await ThirdwebTransaction.SendAndWaitForTransactionReceipt(
+    await ThirdwebTransaction.Create(fundingWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, value: BigInteger.Parse("0.1".ToWei())))
+);
+
+// Sign the authorization to make it point to the delegation contract
+var authorization = await eoaWallet.SignAuthorization(chainId: chainWith7702, contractAddress: delegationContractAddress, willSelfExecute: true);
+Console.WriteLine($"Authorization: {JsonConvert.SerializeObject(authorization, Formatting.Indented)}");
+
+// Execute the delegation
+var tx = await ThirdwebTransaction.Create(eoaWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, authorization: authorization));
+var hash = (await ThirdwebTransaction.SendAndWaitForTransactionReceipt(tx)).TransactionHash;
+Console.WriteLine($"Transaction hash: {hash}");
+
+// Initialize another wallet, the "executor" that will hit the eoa's execute function
+var executorWallet = await InAppWallet.Create(client: client, authProvider: AuthProvider.Google);
+if (!await executorWallet.IsConnected())
+{
+    _ = await executorWallet.LoginWithOauth(
+        isMobile: false,
+        browserOpenAction: (url) =>
+        {
+            var psi = new ProcessStartInfo { FileName = url, UseShellExecute = true };
+            _ = Process.Start(psi);
+        }
+    );
+}
+var executorWalletAddress = await executorWallet.GetAddress();
+Console.WriteLine($"Executor address: {executorWalletAddress}");
+
+// Log erc20 balance of executor before the claim
+var executorBalanceBefore = await erc20Contract.ERC20_BalanceOf(executorWalletAddress);
+Console.WriteLine($"Executor balance before: {executorBalanceBefore}");
+
+// Prepare the claim call
+var claimCallData = erc20Contract.CreateCallData(
+    "claim",
+    new object[]
+    {
+        executorWalletAddress, // receiver
+        100, // quantity
+        Constants.NATIVE_TOKEN_ADDRESS, // currency
+        0, // pricePerToken
+        new object[] { Array.Empty<byte>(), BigInteger.Zero, BigInteger.Zero, Constants.ADDRESS_ZERO }, // allowlistProof
+        Array.Empty<byte>() // data
+    }
+);
+
+// Embed the claim call in the execute call
+var executeCallData = delegationContract.CreateCallData("execute", new object[] { new object[] { claimCallData, eoaWalletAddress, BigInteger.Zero } });
+
+// Execute from the executor wallet targeting the eoa which is pointing to the delegation contract
+var tx2 = await ThirdwebTransaction.Create(executorWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, data: executeCallData));
+var hash2 = (await ThirdwebTransaction.SendAndWaitForTransactionReceipt(tx2)).TransactionHash;
+Console.WriteLine($"Transaction hash: {hash2}");
+
+// Log erc20 balance of executor after the claim
+var executorBalanceAfter = await erc20Contract.ERC20_BalanceOf(executorWalletAddress);
+Console.WriteLine($"Executor balance after: {executorBalanceAfter}");
 
 #region Contract Interaction
 
 // var contract = await ThirdwebContract.Create(client: client, address: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", chain: 1);
-// var nfts = await contract.ERC721_GetAllNFTs();
-// Console.WriteLine($"NFTs: {JsonConvert.SerializeObject(nfts, Formatting.Indented)}");
+// var result = await contract.
 
 #endregion
 
@@ -44,13 +118,7 @@ var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 
 #region AA 0.6
 
-// var smartWallet06 = await SmartWallet.Create(
-//     personalWallet: privateKeyWallet,
-//     chainId: 421614,
-//     gasless: true,
-//     factoryAddress: "0xa8deE7854fb1eA8c13b713585C81d91ea86dAD84",
-//     entryPoint: Constants.ENTRYPOINT_ADDRESS_V06
-// );
+// var smartWallet06 = await SmartWallet.Create(personalWallet: privateKeyWallet, chainId: 421614);
 
 // var receipt06 = await smartWallet06.ExecuteTransaction(new ThirdwebTransactionInput(chainId: 421614, to: await smartWallet06.GetAddress(), value: 0, data: "0x"));
 

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -41,39 +41,28 @@ var eoaWallet = await PrivateKeyWallet.Generate(client);
 var eoaWalletAddress = await eoaWallet.GetAddress();
 Console.WriteLine($"EOA address: {eoaWalletAddress}");
 
-// Temporary - fund eoa wallet
-var fundingWallet = await PrivateKeyWallet.Create(client, privateKey);
-var fundingHash = (
-    await ThirdwebTransaction.SendAndWaitForTransactionReceipt(
-        await ThirdwebTransaction.Create(fundingWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, value: BigInteger.Parse("0.1".ToWei())))
-    )
-).TransactionHash;
-Console.WriteLine($"Funding hash: {fundingHash}");
+// // Temporary - fund eoa wallet
+// var fundingWallet = await PrivateKeyWallet.Create(client, privateKey);
+// var fundingHash = (
+//     await ThirdwebTransaction.SendAndWaitForTransactionReceipt(
+//         await ThirdwebTransaction.Create(fundingWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, value: BigInteger.Parse("0.01".ToWei())))
+//     )
+// ).TransactionHash;
+// Console.WriteLine($"Funding hash: {fundingHash}");
 
 // Sign the authorization to make it point to the delegation contract
-var authorization = await eoaWallet.SignAuthorization(chainId: chainWith7702, contractAddress: delegationContractAddress, willSelfExecute: true);
+var authorization = await eoaWallet.SignAuthorization(chainId: chainWith7702, contractAddress: delegationContractAddress, willSelfExecute: false);
 Console.WriteLine($"Authorization: {JsonConvert.SerializeObject(authorization, Formatting.Indented)}");
 
-// Execute the delegation
-var tx = await ThirdwebTransaction.Create(eoaWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, authorization: authorization));
-var hash = (await ThirdwebTransaction.SendAndWaitForTransactionReceipt(tx)).TransactionHash;
-Console.WriteLine($"Transaction hash: {hash}");
-
 // Initialize another wallet, the "executor" that will hit the eoa's execute function
-var executorWallet = await InAppWallet.Create(client: client, authProvider: AuthProvider.Google);
-if (!await executorWallet.IsConnected())
-{
-    _ = await executorWallet.LoginWithOauth(
-        isMobile: false,
-        browserOpenAction: (url) =>
-        {
-            var psi = new ProcessStartInfo { FileName = url, UseShellExecute = true };
-            _ = Process.Start(psi);
-        }
-    );
-}
+var executorWallet = await PrivateKeyWallet.Create(client, privateKey);
 var executorWalletAddress = await executorWallet.GetAddress();
 Console.WriteLine($"Executor address: {executorWalletAddress}");
+
+// Execute the delegation
+var tx = await ThirdwebTransaction.Create(executorWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, authorization: authorization));
+var hash = (await ThirdwebTransaction.SendAndWaitForTransactionReceipt(tx)).TransactionHash;
+Console.WriteLine($"Transaction hash: {hash}");
 
 // Log erc20 balance of executor before the claim
 var executorBalanceBefore = await erc20Contract.ERC20_BalanceOf(executorWalletAddress);

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -43,9 +43,12 @@ Console.WriteLine($"EOA address: {eoaWalletAddress}");
 
 // Temporary - fund eoa wallet
 var fundingWallet = await PrivateKeyWallet.Create(client, privateKey);
-await ThirdwebTransaction.SendAndWaitForTransactionReceipt(
-    await ThirdwebTransaction.Create(fundingWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, value: BigInteger.Parse("0.1".ToWei())))
-);
+var fundingHash = (
+    await ThirdwebTransaction.SendAndWaitForTransactionReceipt(
+        await ThirdwebTransaction.Create(fundingWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, value: BigInteger.Parse("0.1".ToWei())))
+    )
+).TransactionHash;
+Console.WriteLine($"Funding hash: {fundingHash}");
 
 // Sign the authorization to make it point to the delegation contract
 var authorization = await eoaWallet.SignAuthorization(chainId: chainWith7702, contractAddress: delegationContractAddress, willSelfExecute: true);

--- a/Thirdweb.Console/Program.cs
+++ b/Thirdweb.Console/Program.cs
@@ -18,86 +18,20 @@ var secretKey = Environment.GetEnvironmentVariable("THIRDWEB_SECRET_KEY");
 // Do not use private keys client side, use InAppWallet/SmartWallet instead
 var privateKey = Environment.GetEnvironmentVariable("PRIVATE_KEY");
 
-// Initialize client
-var client = ThirdwebClient.Create(secretKey: secretKey);
+// Fetch timeout options are optional, default is 120000ms
+var client = ThirdwebClient.Create(secretKey: secretKey, fetchTimeoutOptions: new TimeoutOptions(storage: 120000, rpc: 120000, other: 120000));
 
-// Chain and contract addresses
-var chainWith7702 = 7078815900;
-var erc20ContractAddress = "0x852e8247A55C49dc3b7e6f8788347813e562F597"; // Mekong Token
-var delegationContractAddress = "0x7B9E7AFd452666302352D82161B083dF792f7Cf4"; // BatchCallDelegation
+// Create a private key wallet
+var privateKeyWallet = await PrivateKeyWallet.Generate(client: client);
 
-// Initialize contracts normally
-var erc20Contract = await ThirdwebContract.Create(client: client, address: erc20ContractAddress, chain: chainWith7702);
-var delegationContract = await ThirdwebContract.Create(
-    client: client,
-    address: delegationContractAddress,
-    chain: chainWith7702,
-    abi: /*lang=json,strict*/
-    "[{\"anonymous\": false,\"inputs\": [{\"indexed\": true,\"internalType\": \"address\",\"name\": \"to\",\"type\": \"address\"},{\"indexed\": false,\"internalType\": \"uint256\",\"name\": \"value\",\"type\": \"uint256\"},{\"indexed\": false,\"internalType\": \"bytes\",\"name\": \"data\",\"type\": \"bytes\"}],\"name\": \"Executed\",\"type\": \"event\"},{\"inputs\": [{\"components\": [{\"internalType\": \"bytes\",\"name\": \"data\",\"type\": \"bytes\"},{\"internalType\": \"address\",\"name\": \"to\",\"type\": \"address\"},{\"internalType\": \"uint256\",\"name\": \"value\",\"type\": \"uint256\"}],\"internalType\": \"struct BatchCallDelegation.Call[]\",\"name\": \"calls\",\"type\": \"tuple[]\"}],\"name\": \"execute\",\"outputs\": [],\"stateMutability\": \"payable\",\"type\": \"function\"}]"
-);
-
-// Initialize a 7702 EOA
-var eoaWallet = await PrivateKeyWallet.Generate(client);
-var eoaWalletAddress = await eoaWallet.GetAddress();
-Console.WriteLine($"EOA address: {eoaWalletAddress}");
-
-// // Temporary - fund eoa wallet
-// var fundingWallet = await PrivateKeyWallet.Create(client, privateKey);
-// var fundingHash = (
-//     await ThirdwebTransaction.SendAndWaitForTransactionReceipt(
-//         await ThirdwebTransaction.Create(fundingWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, value: BigInteger.Parse("0.01".ToWei())))
-//     )
-// ).TransactionHash;
-// Console.WriteLine($"Funding hash: {fundingHash}");
-
-// Sign the authorization to make it point to the delegation contract
-var authorization = await eoaWallet.SignAuthorization(chainId: chainWith7702, contractAddress: delegationContractAddress, willSelfExecute: false);
-Console.WriteLine($"Authorization: {JsonConvert.SerializeObject(authorization, Formatting.Indented)}");
-
-// Initialize another wallet, the "executor" that will hit the eoa's execute function
-var executorWallet = await PrivateKeyWallet.Create(client, privateKey);
-var executorWalletAddress = await executorWallet.GetAddress();
-Console.WriteLine($"Executor address: {executorWalletAddress}");
-
-// Execute the delegation
-var tx = await ThirdwebTransaction.Create(executorWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, authorization: authorization));
-var hash = (await ThirdwebTransaction.SendAndWaitForTransactionReceipt(tx)).TransactionHash;
-Console.WriteLine($"Transaction hash: {hash}");
-
-// Log erc20 balance of executor before the claim
-var executorBalanceBefore = await erc20Contract.ERC20_BalanceOf(executorWalletAddress);
-Console.WriteLine($"Executor balance before: {executorBalanceBefore}");
-
-// Prepare the claim call
-var claimCallData = erc20Contract.CreateCallData(
-    "claim",
-    new object[]
-    {
-        executorWalletAddress, // receiver
-        100, // quantity
-        Constants.NATIVE_TOKEN_ADDRESS, // currency
-        0, // pricePerToken
-        new object[] { Array.Empty<byte>(), BigInteger.Zero, BigInteger.Zero, Constants.ADDRESS_ZERO }, // allowlistProof
-        Array.Empty<byte>() // data
-    }
-);
-
-// Embed the claim call in the execute call
-var executeCallData = delegationContract.CreateCallData("execute", new object[] { new object[] { claimCallData, eoaWalletAddress, BigInteger.Zero } });
-
-// Execute from the executor wallet targeting the eoa which is pointing to the delegation contract
-var tx2 = await ThirdwebTransaction.Create(executorWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, data: executeCallData));
-var hash2 = (await ThirdwebTransaction.SendAndWaitForTransactionReceipt(tx2)).TransactionHash;
-Console.WriteLine($"Transaction hash: {hash2}");
-
-// Log erc20 balance of executor after the claim
-var executorBalanceAfter = await erc20Contract.ERC20_BalanceOf(executorWalletAddress);
-Console.WriteLine($"Executor balance after: {executorBalanceAfter}");
+// var walletAddress = await privateKeyWallet.GetAddress();
+// Console.WriteLine($"PK Wallet address: {walletAddress}");
 
 #region Contract Interaction
 
 // var contract = await ThirdwebContract.Create(client: client, address: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", chain: 1);
-// var result = await contract.
+// var nfts = await contract.ERC721_GetAllNFTs();
+// Console.WriteLine($"NFTs: {JsonConvert.SerializeObject(nfts, Formatting.Indented)}");
 
 #endregion
 
@@ -110,7 +44,13 @@ Console.WriteLine($"Executor balance after: {executorBalanceAfter}");
 
 #region AA 0.6
 
-// var smartWallet06 = await SmartWallet.Create(personalWallet: privateKeyWallet, chainId: 421614);
+// var smartWallet06 = await SmartWallet.Create(
+//     personalWallet: privateKeyWallet,
+//     chainId: 421614,
+//     gasless: true,
+//     factoryAddress: "0xa8deE7854fb1eA8c13b713585C81d91ea86dAD84",
+//     entryPoint: Constants.ENTRYPOINT_ADDRESS_V06
+// );
 
 // var receipt06 = await smartWallet06.ExecuteTransaction(new ThirdwebTransactionInput(chainId: 421614, to: await smartWallet06.GetAddress(), value: 0, data: "0x"));
 
@@ -148,6 +88,92 @@ Console.WriteLine($"Executor balance after: {executorBalanceAfter}");
 // );
 
 // Console.WriteLine($"Transaction hash: {hash}");
+
+#endregion
+
+#region EIP-7702
+
+// // Chain and contract addresses
+// var chainWith7702 = 911867;
+// var erc20ContractAddress = "0xAA462a5BE0fc5214507FDB4fB2474a7d5c69065b"; // Fake ERC20
+// var delegationContractAddress = "0x654F42b74885EE6803F403f077bc0409f1066c58"; // BatchCallDelegation
+
+// // Initialize contracts normally
+// var erc20Contract = await ThirdwebContract.Create(client: client, address: erc20ContractAddress, chain: chainWith7702);
+// var delegationContract = await ThirdwebContract.Create(client: client, address: delegationContractAddress, chain: chainWith7702);
+
+// // Initialize a (to-be) 7702 EOA
+// var eoaWallet = await PrivateKeyWallet.Generate(client);
+// var eoaWalletAddress = await eoaWallet.GetAddress();
+// Console.WriteLine($"EOA address: {eoaWalletAddress}");
+
+// // Initialize another wallet, the "executor" that will hit the eoa's (to-be) execute function
+// var executorWallet = await PrivateKeyWallet.Generate(client);
+// var executorWalletAddress = await executorWallet.GetAddress();
+// Console.WriteLine($"Executor address: {executorWalletAddress}");
+
+// // Fund the executor wallet
+// var fundingWallet = await PrivateKeyWallet.Create(client, privateKey);
+// var fundingHash = (await fundingWallet.Transfer(chainWith7702, executorWalletAddress, BigInteger.Parse("0.001".ToWei()))).TransactionHash;
+// Console.WriteLine($"Funded Executor Wallet: {fundingHash}");
+
+// // Sign the authorization to make it point to the delegation contract
+// var authorization = await eoaWallet.SignAuthorization(chainId: chainWith7702, contractAddress: delegationContractAddress, willSelfExecute: false);
+// Console.WriteLine($"Authorization: {JsonConvert.SerializeObject(authorization, Formatting.Indented)}");
+
+// // Execute the delegation
+// var tx = await ThirdwebTransaction.Create(executorWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: executorWalletAddress, authorization: authorization));
+// var hash = (await ThirdwebTransaction.SendAndWaitForTransactionReceipt(tx)).TransactionHash;
+// Console.WriteLine($"Authorization execution transaction hash: {hash}");
+
+// // Prove that code has been deployed to the eoa
+// var rpc = ThirdwebRPC.GetRpcInstance(client, chainWith7702);
+// var code = await rpc.SendRequestAsync<string>("eth_getCode", eoaWalletAddress, "latest");
+// Console.WriteLine($"EOA code: {code}");
+
+// // Log erc20 balance of executor before the claim
+// var executorBalanceBefore = await erc20Contract.ERC20_BalanceOf(executorWalletAddress);
+// Console.WriteLine($"Executor balance before: {executorBalanceBefore}");
+
+// // Prepare the claim call
+// var claimCallData = erc20Contract.CreateCallData(
+//     "claim",
+//     new object[]
+//     {
+//         executorWalletAddress, // receiver
+//         100, // quantity
+//         Constants.NATIVE_TOKEN_ADDRESS, // currency
+//         0, // pricePerToken
+//         new object[] { Array.Empty<byte>(), BigInteger.Zero, BigInteger.Zero, Constants.ADDRESS_ZERO }, // allowlistProof
+//         Array.Empty<byte>() // data
+//     }
+// );
+
+// // Embed the claim call in the execute call
+// var executeCallData = delegationContract.CreateCallData(
+//     method: "execute",
+//     parameters: new object[]
+//     {
+//         new List<Thirdweb.Console.Call>
+//         {
+//             new()
+//             {
+//                 Data = claimCallData.HexToBytes(),
+//                 To = erc20ContractAddress,
+//                 Value = BigInteger.Zero
+//             }
+//         }
+//     }
+// );
+
+// // Execute from the executor wallet targeting the eoa which is pointing to the delegation contract
+// var tx2 = await ThirdwebTransaction.Create(executorWallet, new ThirdwebTransactionInput(chainId: chainWith7702, to: eoaWalletAddress, data: executeCallData));
+// var hash2 = (await ThirdwebTransaction.SendAndWaitForTransactionReceipt(tx2)).TransactionHash;
+// Console.WriteLine($"Token claim transaction hash: {hash2}");
+
+// // Log erc20 balance of executor after the claim
+// var executorBalanceAfter = await erc20Contract.ERC20_BalanceOf(executorWalletAddress);
+// Console.WriteLine($"Executor balance after: {executorBalanceAfter}");
 
 #endregion
 

--- a/Thirdweb.Tests/Thirdweb.Contracts/Thirdweb.Contracts.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Contracts/Thirdweb.Contracts.Tests.cs
@@ -79,6 +79,14 @@ public class ContractsTests : BaseTests
     }
 
     [Fact(Timeout = 120000)]
+    public async Task ReadTest_4Bytes()
+    {
+        var contract = await this.GetContract();
+        var result = await ThirdwebContract.Read<string>(contract, "0x06fdde03");
+        Assert.Equal("Kitty DropERC20", result);
+    }
+
+    [Fact(Timeout = 120000)]
     public async Task ReadTest_FullSig()
     {
         var contract = await this.GetContract();

--- a/Thirdweb.Tests/Thirdweb.Utils/Thirdweb.Utils.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Utils/Thirdweb.Utils.Tests.cs
@@ -866,4 +866,32 @@ public class UtilsTests : BaseTests
 
         Assert.Equal(expectedJObject, processedJObject);
     }
+
+    [Fact]
+    public void DecodeTransaction_1559WithAuthList()
+    {
+        var signedTxStr =
+            "0x04f8ca830de9fb8082011882031083025bee94ff5d95e5aa1b5af3f106079518228a92818737728080c0f85ef85c830de9fb94654f42b74885ee6803f403f077bc0409f1066c588080a0a5caed9b0c46657a452250a3279f45937940c87c45854aead6a902d99bc638f39faa58026c6b018d36b8935a42f2bcf68097c712c9f09ca014c70887678e08a980a027ecc69e66eb9e28cbe6edab10fc827fcb6d2a34cdcb89d8b6aabc6e35608692a0750d306b04a50a35de57bd6aca11f207a8dd404f9d92502ce6e3817e52f79a1c";
+        (var txInput, var signature) = Utils.DecodeTransaction(signedTxStr);
+        Assert.Equal("0xfF5D95e5aA1B5Af3F106079518228A9281873772", txInput.To);
+        Assert.Equal("0x", txInput.Data);
+        Assert.Equal(0, txInput.Value.Value);
+        Assert.NotNull(txInput.AuthorizationList);
+        _ = Assert.Single(txInput.AuthorizationList);
+        Assert.Equal("0x654F42b74885EE6803F403f077bc0409f1066c58", txInput.AuthorizationList[0].Address);
+        Assert.Equal("0xde9fb", txInput.AuthorizationList[0].ChainId);
+        Assert.Equal("0x0", txInput.AuthorizationList[0].Nonce);
+
+        (txInput, var signature2) = Utils.DecodeTransaction(signedTxStr.HexToBytes());
+        Assert.Equal("0xfF5D95e5aA1B5Af3F106079518228A9281873772", txInput.To);
+        Assert.Equal("0x", txInput.Data);
+        Assert.Equal(0, txInput.Value.Value);
+        Assert.NotNull(txInput.AuthorizationList);
+        _ = Assert.Single(txInput.AuthorizationList);
+        Assert.Equal("0x654F42b74885EE6803F403f077bc0409f1066c58", txInput.AuthorizationList[0].Address);
+        Assert.Equal("0xde9fb", txInput.AuthorizationList[0].ChainId);
+        Assert.Equal("0x0", txInput.AuthorizationList[0].Nonce);
+
+        Assert.Equal(signature, signature2);
+    }
 }

--- a/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.PrivateKeyWallet.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.PrivateKeyWallet.Tests.cs
@@ -209,16 +209,16 @@ public class PrivateKeyWalletTests : BaseTests
     public async Task SignTransaction_Success()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput(421614)
-        {
-            From = await account.GetAddress(),
-            To = Constants.ADDRESS_ZERO,
-            // Value = new HexBigInteger(0),
-            Gas = new HexBigInteger(21000),
-            // Data = "0x",
-            Nonce = new HexBigInteger(99999999999),
-            GasPrice = new HexBigInteger(10000000000),
-        };
+        var transaction = new ThirdwebTransactionInput(
+            chainId: 421614,
+            from: await account.GetAddress(),
+            to: Constants.ADDRESS_ZERO,
+            value: 0,
+            gas: 21000,
+            data: "0x",
+            nonce: 99999999999,
+            gasPrice: 10000000000
+        );
         var signature = await account.SignTransaction(transaction);
         Assert.NotNull(signature);
     }
@@ -227,15 +227,7 @@ public class PrivateKeyWalletTests : BaseTests
     public async Task SignTransaction_NoFrom_Success()
     {
         var account = await this.GetAccount();
-        var transaction = new ThirdwebTransactionInput(421614)
-        {
-            To = Constants.ADDRESS_ZERO,
-            // Value = new HexBigInteger(0),
-            Gas = new HexBigInteger(21000),
-            Data = "0x",
-            Nonce = new HexBigInteger(99999999999),
-            GasPrice = new HexBigInteger(10000000000),
-        };
+        var transaction = new ThirdwebTransactionInput(chainId: 421614, to: Constants.ADDRESS_ZERO, value: 0, gas: 21000, data: "0x", nonce: 99999999999, gasPrice: 10000000000);
         var signature = await account.SignTransaction(transaction);
         Assert.NotNull(signature);
     }

--- a/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.PrivateKeyWallet.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.PrivateKeyWallet.Tests.cs
@@ -224,6 +224,26 @@ public class PrivateKeyWalletTests : BaseTests
     }
 
     [Fact(Timeout = 120000)]
+    public async Task SignTransaction_WithAuthorizationList_Success()
+    {
+        var account = await this.GetAccount();
+        var authorization = await account.SignAuthorization(421614, Constants.ADDRESS_ZERO, false);
+        var transaction = new ThirdwebTransactionInput(
+            chainId: 421614,
+            from: await account.GetAddress(),
+            to: Constants.ADDRESS_ZERO,
+            value: 0,
+            gas: 21000,
+            data: "0x",
+            nonce: 99999999999,
+            gasPrice: 10000000000,
+            authorization: authorization
+        );
+        var signature = await account.SignTransaction(transaction);
+        Assert.NotNull(signature);
+    }
+
+    [Fact(Timeout = 120000)]
     public async Task SignTransaction_NoFrom_Success()
     {
         var account = await this.GetAccount();
@@ -460,5 +480,27 @@ public class PrivateKeyWalletTests : BaseTests
 
         Assert.NotNull(privateKey);
         Assert.Equal(privateKey, await wallet.Export());
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SignAuthorization_SelfExecution()
+    {
+        var wallet = await PrivateKeyWallet.Generate(this.Client);
+        var chainId = 911867;
+        var targetAddress = "0x654F42b74885EE6803F403f077bc0409f1066c58";
+
+        var currentNonce = await wallet.GetTransactionCount(chainId);
+
+        var authorization = await wallet.SignAuthorization(chainId: chainId, contractAddress: targetAddress, willSelfExecute: false);
+
+        Assert.Equal(chainId.NumberToHex(), authorization.ChainId);
+        Assert.Equal(targetAddress, authorization.Address);
+        Assert.True(authorization.Nonce.HexToNumber() == currentNonce);
+
+        authorization = await wallet.SignAuthorization(chainId: chainId, contractAddress: targetAddress, willSelfExecute: true);
+
+        Assert.Equal(chainId.NumberToHex(), authorization.ChainId);
+        Assert.Equal(targetAddress, authorization.Address);
+        Assert.True(authorization.Nonce.HexToNumber() == currentNonce + 1);
     }
 }

--- a/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.SmartWallet.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Wallets/Thirdweb.SmartWallet.Tests.cs
@@ -364,6 +364,18 @@ public class SmartWalletTests : BaseTests
         Assert.NotEqual(addy1, addy2);
     }
 
+    [Fact(Timeout = 120000)]
+    public async Task SignAuthorization_WithPrivateKeyWallet_Success()
+    {
+        var smartWallet = await SmartWallet.Create(personalWallet: await PrivateKeyWallet.Generate(this.Client), chainId: 421614);
+        var smartWalletSigner = await smartWallet.GetPersonalWallet();
+        var signature1 = await smartWallet.SignAuthorization(chainId: 421614, contractAddress: Constants.ADDRESS_ZERO, willSelfExecute: true);
+        var signature2 = await smartWalletSigner.SignAuthorization(chainId: 421614, contractAddress: Constants.ADDRESS_ZERO, willSelfExecute: true);
+        Assert.Equal(signature1.ChainId, signature2.ChainId);
+        Assert.Equal(signature1.Address, signature2.Address);
+        Assert.Equal(signature1.Nonce, signature2.Nonce);
+    }
+
     // [Fact(Timeout = 120000)]
     // public async Task MultiChainTransaction_Success()
     // {

--- a/Thirdweb/Thirdweb.Contracts/ThirdwebContract.cs
+++ b/Thirdweb/Thirdweb.Contracts/ThirdwebContract.cs
@@ -182,19 +182,6 @@ public class ThirdwebContract
     {
         var contractRaw = new Contract(null, contract.Abi, contract.Address);
         var function = GetFunctionMatchSignature(contractRaw, method, parameters);
-        if (function == null)
-        {
-            if (method.Contains('('))
-            {
-                var canonicalSignature = ExtractCanonicalSignature(method);
-                var selector = Nethereum.Util.Sha3Keccack.Current.CalculateHash(canonicalSignature)[..8];
-                function = contractRaw.GetFunctionBySignature(selector);
-            }
-            else
-            {
-                throw new ArgumentException("Method signature not found in contract ABI.");
-            }
-        }
         return (function.GetData(parameters), function);
     }
 
@@ -207,6 +194,11 @@ public class ThirdwebContract
     /// <returns>The matching function, or null if no match is found.</returns>
     private static Function GetFunctionMatchSignature(Contract contract, string functionName, params object[] args)
     {
+        if (functionName.StartsWith("0x"))
+        {
+            return contract.GetFunctionBySignature(functionName);
+        }
+
         var abi = contract.ContractBuilder.ContractABI;
         var functions = abi.Functions;
         var paramsCount = args?.Length ?? 0;
@@ -218,7 +210,17 @@ public class ThirdwebContract
                 return contract.GetFunctionBySignature(sha);
             }
         }
-        return null;
+
+        if (functionName.Contains('('))
+        {
+            var canonicalSignature = ExtractCanonicalSignature(functionName);
+            var selector = Utils.HashMessage(canonicalSignature)[..8];
+            return contract.GetFunctionBySignature(selector);
+        }
+        else
+        {
+            throw new ArgumentException("Method signature not found in contract ABI.");
+        }
     }
 
     /// <summary>

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
@@ -271,12 +271,12 @@ public class ThirdwebTransaction
         if (isZkSync)
         {
             var hex = (await rpc.SendRequestAsync<JToken>("zks_estimateFee", transaction.Input).ConfigureAwait(false))["gas_limit"].ToString();
-            baseGas = hex.HexToBigInt();
+            baseGas = hex.HexToNumber();
         }
         else
         {
             var hex = await rpc.SendRequestAsync<string>("eth_estimateGas", transaction.Input).ConfigureAwait(false);
-            baseGas = hex.HexToBigInt();
+            baseGas = hex.HexToNumber();
         }
         return baseGas * 10 / divider;
     }

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
@@ -262,16 +262,32 @@ public class ThirdwebTransaction
     {
         var rpc = ThirdwebRPC.GetRpcInstance(transaction._wallet.Client, transaction.Input.ChainId.Value);
 
-        if (await Utils.IsZkSync(transaction._wallet.Client, transaction.Input.ChainId.Value).ConfigureAwait(false))
+        // Remove when https://github.com/ethereum/execution-apis/issues/561 is in
+        var txInput = new ThirdwebTransactionInput(
+            chainId: transaction.Input.ChainId,
+            from: transaction.Input.From,
+            to: transaction.Input.To,
+            nonce: transaction.Input.Nonce,
+            value: transaction.Input.Value,
+            data: transaction.Input.Data,
+            zkSync: transaction.Input.ZkSync
+        );
+
+        var extraGas = transaction.Input.AuthorizationList == null ? 0 : 100000;
+        BigInteger finalGas;
+
+        if (await Utils.IsZkSync(transaction._wallet.Client, txInput.ChainId.Value).ConfigureAwait(false))
         {
-            var hex = (await rpc.SendRequestAsync<JToken>("zks_estimateFee", transaction.Input).ConfigureAwait(false))["gas_limit"].ToString();
-            return new HexBigInteger(hex).Value * 10 / 5;
+            var hex = (await rpc.SendRequestAsync<JToken>("zks_estimateFee", txInput).ConfigureAwait(false))["gas_limit"].ToString();
+            finalGas = hex.HexToBigInt() * 2;
         }
         else
         {
-            var hex = await rpc.SendRequestAsync<string>("eth_estimateGas", transaction.Input).ConfigureAwait(false);
-            return new HexBigInteger(hex).Value * 10 / 7;
+            var hex = await rpc.SendRequestAsync<string>("eth_estimateGas", txInput).ConfigureAwait(false);
+            finalGas = hex.HexToBigInt() * 2;
         }
+
+        return finalGas + extraGas;
     }
 
     /// <summary>
@@ -358,32 +374,7 @@ public class ThirdwebTransaction
         var rpc = ThirdwebRPC.GetRpcInstance(transaction._wallet.Client, transaction.Input.ChainId.Value);
         string hash;
 
-        if (transaction.Input.AuthorizationList != null)
-        {
-            var authorization = transaction.Input.AuthorizationList[0];
-            hash = await rpc.SendRequestAsync<string>(
-                    "wallet_sendTransaction",
-                    new
-                    {
-                        authorizationList = new[]
-                        {
-                            new
-                            {
-                                address = authorization.Address,
-                                chainId = authorization.ChainId.HexToBigInt(),
-                                nonce = authorization.Nonce.HexToBigInt(),
-                                r = authorization.R,
-                                s = authorization.S,
-                                yParity = authorization.YParity == "0x00" ? 0 : 1
-                            }
-                        },
-                        data = transaction.Input.Data,
-                        to = transaction.Input.To,
-                    }
-                )
-                .ConfigureAwait(false);
-        }
-        else if (await Utils.IsZkSync(transaction._wallet.Client, transaction.Input.ChainId.Value).ConfigureAwait(false) && transaction.Input.ZkSync.HasValue)
+        if (await Utils.IsZkSync(transaction._wallet.Client, transaction.Input.ChainId.Value).ConfigureAwait(false) && transaction.Input.ZkSync.HasValue)
         {
             var zkTx = await ConvertToZkSyncTransaction(transaction).ConfigureAwait(false);
             var zkTxSigned = await EIP712.GenerateSignature_ZkSyncTransaction("zkSync", "2", transaction.Input.ChainId.Value, zkTx, transaction._wallet).ConfigureAwait(false);

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
@@ -261,33 +261,24 @@ public class ThirdwebTransaction
     public static async Task<BigInteger> EstimateGasLimit(ThirdwebTransaction transaction)
     {
         var rpc = ThirdwebRPC.GetRpcInstance(transaction._wallet.Client, transaction.Input.ChainId.Value);
-
-        // Remove when https://github.com/ethereum/execution-apis/issues/561 is in
-        var txInput = new ThirdwebTransactionInput(
-            chainId: transaction.Input.ChainId,
-            from: transaction.Input.From,
-            to: transaction.Input.To,
-            nonce: transaction.Input.Nonce,
-            value: transaction.Input.Value,
-            data: transaction.Input.Data,
-            zkSync: transaction.Input.ZkSync
-        );
-
-        var extraGas = transaction.Input.AuthorizationList == null ? 0 : 100000;
-        BigInteger finalGas;
-
-        if (await Utils.IsZkSync(transaction._wallet.Client, txInput.ChainId.Value).ConfigureAwait(false))
+        var isZkSync = await Utils.IsZkSync(transaction._wallet.Client, transaction.Input.ChainId.Value).ConfigureAwait(false);
+        BigInteger divider = isZkSync
+            ? 7
+            : transaction.Input.AuthorizationList == null
+                ? 5
+                : 3;
+        BigInteger baseGas;
+        if (isZkSync)
         {
-            var hex = (await rpc.SendRequestAsync<JToken>("zks_estimateFee", txInput).ConfigureAwait(false))["gas_limit"].ToString();
-            finalGas = hex.HexToBigInt() * 2;
+            var hex = (await rpc.SendRequestAsync<JToken>("zks_estimateFee", transaction.Input).ConfigureAwait(false))["gas_limit"].ToString();
+            baseGas = hex.HexToBigInt();
         }
         else
         {
-            var hex = await rpc.SendRequestAsync<string>("eth_estimateGas", txInput).ConfigureAwait(false);
-            finalGas = hex.HexToBigInt() * 2;
+            var hex = await rpc.SendRequestAsync<string>("eth_estimateGas", transaction.Input).ConfigureAwait(false);
+            baseGas = hex.HexToBigInt();
         }
-
-        return finalGas + extraGas;
+        return baseGas * 10 / divider;
     }
 
     /// <summary>

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransaction.cs
@@ -357,7 +357,33 @@ public class ThirdwebTransaction
 
         var rpc = ThirdwebRPC.GetRpcInstance(transaction._wallet.Client, transaction.Input.ChainId.Value);
         string hash;
-        if (await Utils.IsZkSync(transaction._wallet.Client, transaction.Input.ChainId.Value).ConfigureAwait(false) && transaction.Input.ZkSync.HasValue)
+
+        if (transaction.Input.AuthorizationList != null)
+        {
+            var authorization = transaction.Input.AuthorizationList[0];
+            hash = await rpc.SendRequestAsync<string>(
+                    "wallet_sendTransaction",
+                    new
+                    {
+                        authorizationList = new[]
+                        {
+                            new
+                            {
+                                address = authorization.Address,
+                                chainId = authorization.ChainId.HexToBigInt(),
+                                nonce = authorization.Nonce.HexToBigInt(),
+                                r = authorization.R,
+                                s = authorization.S,
+                                yParity = authorization.YParity == "0x00" ? 0 : 1
+                            }
+                        },
+                        data = transaction.Input.Data,
+                        to = transaction.Input.To,
+                    }
+                )
+                .ConfigureAwait(false);
+        }
+        else if (await Utils.IsZkSync(transaction._wallet.Client, transaction.Input.ChainId.Value).ConfigureAwait(false) && transaction.Input.ZkSync.HasValue)
         {
             var zkTx = await ConvertToZkSyncTransaction(transaction).ConfigureAwait(false);
             var zkTxSigned = await EIP712.GenerateSignature_ZkSyncTransaction("zkSync", "2", transaction.Input.ChainId.Value, zkTx, transaction._wallet).ConfigureAwait(false);

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransactionInput.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransactionInput.cs
@@ -26,7 +26,8 @@ public class ThirdwebTransactionInput
         string data = null,
         BigInteger? maxFeePerGas = null,
         BigInteger? maxPriorityFeePerGas = null,
-        ZkSyncOptions? zkSync = null
+        ZkSyncOptions? zkSync = null,
+        EIP7702Authorization? authorization = null
     )
     {
         this.ChainId = chainId > 0 ? new HexBigInteger(chainId) : throw new ArgumentException("Invalid Chain ID");
@@ -40,6 +41,7 @@ public class ThirdwebTransactionInput
         this.MaxFeePerGas = maxFeePerGas == null ? null : new HexBigInteger(maxFeePerGas.Value);
         this.MaxPriorityFeePerGas = maxPriorityFeePerGas == null ? null : new HexBigInteger(maxPriorityFeePerGas.Value);
         this.ZkSync = zkSync;
+        this.AuthorizationList = authorization == null ? null : new List<EIP7702Authorization> { authorization.Value };
     }
 
     /// <summary>
@@ -123,6 +125,11 @@ public class ThirdwebTransactionInput
     /// </summary>
     [JsonProperty(PropertyName = "zkSyncOptions", NullValueHandling = NullValueHandling.Ignore)]
     public ZkSyncOptions? ZkSync { get; set; }
+
+#nullable enable
+    [JsonProperty(PropertyName = "authorizationList", NullValueHandling = NullValueHandling.Ignore)]
+    public List<EIP7702Authorization>? AuthorizationList { get; set; }
+#nullable disable
 }
 
 /// <summary>
@@ -177,5 +184,36 @@ public struct ZkSyncOptions
             this.GasPerPubdataByteLimit = gasPerPubdataByteLimit;
             this.FactoryDeps = factoryDeps ?? new List<byte[]>();
         }
+    }
+}
+
+public struct EIP7702Authorization
+{
+    [JsonProperty(PropertyName = "chainId")]
+    public string ChainId { get; set; }
+
+    [JsonProperty(PropertyName = "address")]
+    public string Address { get; set; }
+
+    [JsonProperty(PropertyName = "nonce")]
+    public string Nonce { get; set; }
+
+    [JsonProperty(PropertyName = "yParity")]
+    public string YParity { get; set; }
+
+    [JsonProperty(PropertyName = "r")]
+    public string R { get; set; }
+
+    [JsonProperty(PropertyName = "s")]
+    public string S { get; set; }
+
+    public EIP7702Authorization(BigInteger chainId, string address, BigInteger nonce, byte[] yParity, byte[] r, byte[] s)
+    {
+        this.ChainId = new HexBigInteger(chainId).HexValue;
+        this.Address = address.EnsureHexPrefix();
+        this.Nonce = new HexBigInteger(nonce).HexValue;
+        this.YParity = yParity.BytesToHex();
+        this.R = r.BytesToHex();
+        this.S = s.BytesToHex();
     }
 }

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransactionInput.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransactionInput.cs
@@ -207,12 +207,12 @@ public struct EIP7702Authorization
     [JsonProperty(PropertyName = "s")]
     public string S { get; set; }
 
-    public EIP7702Authorization(BigInteger chainId, string address, BigInteger nonce, byte[] v, byte[] r, byte[] s)
+    public EIP7702Authorization(BigInteger chainId, string address, BigInteger nonce, byte[] yParity, byte[] r, byte[] s)
     {
         this.ChainId = new HexBigInteger(chainId).HexValue;
         this.Address = address;
         this.Nonce = new HexBigInteger(nonce).HexValue;
-        this.YParity = v.BytesToHex();
+        this.YParity = yParity.BytesToHex();
         this.R = r.BytesToHex();
         this.S = s.BytesToHex();
     }

--- a/Thirdweb/Thirdweb.Transactions/ThirdwebTransactionInput.cs
+++ b/Thirdweb/Thirdweb.Transactions/ThirdwebTransactionInput.cs
@@ -207,12 +207,12 @@ public struct EIP7702Authorization
     [JsonProperty(PropertyName = "s")]
     public string S { get; set; }
 
-    public EIP7702Authorization(BigInteger chainId, string address, BigInteger nonce, byte[] yParity, byte[] r, byte[] s)
+    public EIP7702Authorization(BigInteger chainId, string address, BigInteger nonce, byte[] v, byte[] r, byte[] s)
     {
         this.ChainId = new HexBigInteger(chainId).HexValue;
-        this.Address = address.EnsureHexPrefix();
+        this.Address = address;
         this.Nonce = new HexBigInteger(nonce).HexValue;
-        this.YParity = yParity.BytesToHex();
+        this.YParity = v.BytesToHex();
         this.R = r.BytesToHex();
         this.S = s.BytesToHex();
     }

--- a/Thirdweb/Thirdweb.Utils/Utils.cs
+++ b/Thirdweb/Thirdweb.Utils/Utils.cs
@@ -12,6 +12,8 @@ using Nethereum.ABI.Model;
 using Nethereum.Contracts;
 using Nethereum.Hex.HexConvertors.Extensions;
 using Nethereum.Hex.HexTypes;
+using Nethereum.Model;
+using Nethereum.RLP;
 using Nethereum.Signer;
 using Nethereum.Util;
 using Newtonsoft.Json;
@@ -1055,5 +1057,93 @@ public static partial class Utils
         }
 
         return trimmed.ToArray();
+    }
+
+    /// <summary>
+    /// Decodes the given RLP-encoded transaction data.
+    /// </summary>
+    /// <param name="signedRlpData">The RLP-encoded signed transaction data.</param>
+    /// <returns>The decoded transaction input and signature.</returns>
+    public static (ThirdwebTransactionInput transactionInput, string signature) DecodeTransaction(string signedRlpData)
+    {
+        return DecodeTransaction(signedRlpData.HexToBytes());
+    }
+
+    /// <summary>
+    /// Decodes the given RLP-encoded transaction data.
+    /// </summary>
+    /// <param name="signedRlpData">The RLP-encoded signed transaction data.</param>
+    /// <returns>The decoded transaction input and signature.</returns>
+    public static (ThirdwebTransactionInput transactionInput, string signature) DecodeTransaction(byte[] signedRlpData)
+    {
+        var maybeType = signedRlpData[0];
+        if (maybeType is 0x04 or 0x02)
+        {
+            signedRlpData = signedRlpData.Skip(1).ToArray();
+        }
+
+        var decodedList = RLP.Decode(signedRlpData);
+        var decodedElements = (RLPCollection)decodedList;
+        var chainId = decodedElements[0].RLPData.ToBigIntegerFromRLPDecoded();
+        var nonce = decodedElements[1].RLPData.ToBigIntegerFromRLPDecoded();
+        var maxPriorityFeePerGas = decodedElements[2].RLPData.ToBigIntegerFromRLPDecoded();
+        var maxFeePerGas = decodedElements[3].RLPData.ToBigIntegerFromRLPDecoded();
+        var gasLimit = decodedElements[4].RLPData.ToBigIntegerFromRLPDecoded();
+        var receiverAddress = decodedElements[5].RLPData?.BytesToHex();
+        var amount = decodedElements[6].RLPData.ToBigIntegerFromRLPDecoded();
+        var data = decodedElements[7].RLPData?.BytesToHex();
+        // 8th decoded element is access list
+        var authorizations = DecodeAutorizationList(decodedElements[9]?.RLPData);
+
+        var signature = RLPSignedDataDecoder.DecodeSignature(decodedElements, 10);
+        return (
+            new ThirdwebTransactionInput(
+                chainId: chainId,
+                to: receiverAddress,
+                nonce: nonce,
+                gas: gasLimit,
+                value: amount,
+                data: data,
+                maxFeePerGas: maxFeePerGas,
+                maxPriorityFeePerGas: maxPriorityFeePerGas
+            )
+            {
+                AuthorizationList = authorizations
+            },
+            signature.CreateStringSignature()
+        );
+    }
+
+    /// <summary>
+    /// Decodes the given RLP-encoded authorization list.
+    /// </summary>
+    public static List<EIP7702Authorization> DecodeAutorizationList(byte[] authorizationListEncoded)
+    {
+        if (authorizationListEncoded == null || authorizationListEncoded.Length == 0 || authorizationListEncoded[0] == RLP.OFFSET_SHORT_LIST)
+        {
+            return null;
+        }
+
+        var decodedList = (RLPCollection)RLP.Decode(authorizationListEncoded);
+
+        var authorizationLists = new List<EIP7702Authorization>();
+        foreach (var rlpElement in decodedList)
+        {
+            var decodedItem = (RLPCollection)rlpElement;
+            var authorizationListItem = new EIP7702Authorization
+            {
+                ChainId = new HexBigInteger(decodedItem[0].RLPData.ToBigIntegerFromRLPDecoded()).HexValue,
+                Address = decodedItem[1].RLPData.BytesToHex(),
+                Nonce = new HexBigInteger(decodedItem[2].RLPData.ToBigIntegerFromRLPDecoded()).HexValue
+            };
+            var signature = RLPSignedDataDecoder.DecodeSignature(decodedItem, 3);
+            authorizationListItem.YParity = signature.V.BytesToHex();
+            authorizationListItem.R = signature.R.BytesToHex();
+            authorizationListItem.S = signature.S.BytesToHex();
+
+            authorizationLists.Add(authorizationListItem);
+        }
+
+        return authorizationLists;
     }
 }

--- a/Thirdweb/Thirdweb.Utils/Utils.cs
+++ b/Thirdweb/Thirdweb.Utils/Utils.cs
@@ -167,7 +167,7 @@ public static partial class Utils
     /// </summary>
     public static string NumberToHex(this int number)
     {
-        return NumberToHex(number);
+        return NumberToHex(new BigInteger(number));
     }
 
     /// <summary>
@@ -175,7 +175,7 @@ public static partial class Utils
     /// </summary>
     public static string NumberToHex(this long number)
     {
-        return NumberToHex(number);
+        return NumberToHex(new BigInteger(number));
     }
 
     /// <summary>

--- a/Thirdweb/Thirdweb.Utils/Utils.cs
+++ b/Thirdweb/Thirdweb.Utils/Utils.cs
@@ -1034,4 +1034,26 @@ public static partial class Utils
         var encodedParams = encoder.GetABIEncoded(new ABIValue("address", address), new ABIValue("bytes", data), new ABIValue("bytes", signature));
         return HexConcat(encodedParams.BytesToHex(), Constants.ERC_6492_MAGIC_VALUE);
     }
+
+    /// <summary>
+    /// Removes leading zeroes from the given byte array.
+    /// </summary>
+    public static byte[] TrimZeroes(this byte[] bytes)
+    {
+        var trimmed = new List<byte>();
+        var previousByteWasZero = true;
+
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            if (previousByteWasZero && bytes[i] == 0)
+            {
+                continue;
+            }
+
+            previousByteWasZero = false;
+            trimmed.Add(bytes[i]);
+        }
+
+        return trimmed.ToArray();
+    }
 }

--- a/Thirdweb/Thirdweb.Utils/Utils.cs
+++ b/Thirdweb/Thirdweb.Utils/Utils.cs
@@ -138,9 +138,44 @@ public static partial class Utils
     /// </summary>
     /// <param name="hex">The hex string to convert.</param>
     /// <returns>The big integer.</returns>
+    [Obsolete("Use HexToNumber instead.")]
     public static BigInteger HexToBigInt(this string hex)
     {
         return new HexBigInteger(hex).Value;
+    }
+
+    /// <summary>
+    /// Converts the given hex string to a big integer.
+    /// </summary>
+    /// <param name="hex">The hex string to convert.</param>
+    /// <returns>The big integer.</returns>
+    public static BigInteger HexToNumber(this string hex)
+    {
+        return new HexBigInteger(hex).Value;
+    }
+
+    /// <summary>
+    /// Converts the given big integer to a hex string.
+    /// </summary>
+    public static string NumberToHex(this BigInteger number)
+    {
+        return new HexBigInteger(number).HexValue;
+    }
+
+    /// <summary>
+    /// Converts the given integer to a hex string.
+    /// </summary>
+    public static string NumberToHex(this int number)
+    {
+        return NumberToHex(number);
+    }
+
+    /// <summary>
+    /// Converts the given long to a hex string.
+    /// </summary>
+    public static string NumberToHex(this long number)
+    {
+        return NumberToHex(number);
     }
 
     /// <summary>
@@ -885,7 +920,7 @@ public static partial class Utils
     {
         var rpc = ThirdwebRPC.GetRpcInstance(client, chainId);
         var hex = await rpc.SendRequestAsync<string>("eth_gasPrice").ConfigureAwait(false);
-        var gasPrice = hex.HexToBigInt();
+        var gasPrice = hex.HexToNumber();
         return withBump ? gasPrice * 10 / 9 : gasPrice;
     }
 
@@ -1099,7 +1134,7 @@ public static partial class Utils
         return (
             new ThirdwebTransactionInput(
                 chainId: chainId,
-                to: receiverAddress,
+                to: receiverAddress.ToChecksumAddress(),
                 nonce: nonce,
                 gas: gasLimit,
                 value: amount,
@@ -1133,7 +1168,7 @@ public static partial class Utils
             var authorizationListItem = new EIP7702Authorization
             {
                 ChainId = new HexBigInteger(decodedItem[0].RLPData.ToBigIntegerFromRLPDecoded()).HexValue,
-                Address = decodedItem[1].RLPData.BytesToHex(),
+                Address = decodedItem[1].RLPData.BytesToHex().ToChecksumAddress(),
                 Nonce = new HexBigInteger(decodedItem[2].RLPData.ToBigIntegerFromRLPDecoded()).HexValue
             };
             var signature = RLPSignedDataDecoder.DecodeSignature(decodedItem, 3);

--- a/Thirdweb/Thirdweb.Utils/Utils.cs
+++ b/Thirdweb/Thirdweb.Utils/Utils.cs
@@ -1076,8 +1076,8 @@ public static partial class Utils
     /// <returns>The decoded transaction input and signature.</returns>
     public static (ThirdwebTransactionInput transactionInput, string signature) DecodeTransaction(byte[] signedRlpData)
     {
-        var maybeType = signedRlpData[0];
-        if (maybeType is 0x04 or 0x02)
+        var txType = signedRlpData[0];
+        if (txType is 0x04 or 0x02)
         {
             signedRlpData = signedRlpData.Skip(1).ToArray();
         }
@@ -1093,9 +1093,9 @@ public static partial class Utils
         var amount = decodedElements[6].RLPData.ToBigIntegerFromRLPDecoded();
         var data = decodedElements[7].RLPData?.BytesToHex();
         // 8th decoded element is access list
-        var authorizations = DecodeAutorizationList(decodedElements[9]?.RLPData);
+        var authorizations = txType == 0x04 ? DecodeAutorizationList(decodedElements[9]?.RLPData) : null;
 
-        var signature = RLPSignedDataDecoder.DecodeSignature(decodedElements, 10);
+        var signature = RLPSignedDataDecoder.DecodeSignature(decodedElements, txType == 0x04 ? 10 : 9);
         return (
             new ThirdwebTransactionInput(
                 chainId: chainId,
@@ -1145,5 +1145,15 @@ public static partial class Utils
         }
 
         return authorizationLists;
+    }
+
+    internal static byte[] ToByteArrayForRLPEncoding(this BigInteger value)
+    {
+        if (value == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        return value.ToBytesForRLPEncoding();
     }
 }

--- a/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
@@ -1,4 +1,5 @@
-﻿using Nethereum.ABI.EIP712;
+﻿using System.Numerics;
+using Nethereum.ABI.EIP712;
 using Newtonsoft.Json;
 
 namespace Thirdweb;
@@ -150,7 +151,7 @@ public interface IThirdwebWallet
         Action<string> browserOpenAction = null,
         string mobileRedirectScheme = "thirdweb://",
         IThirdwebBrowser browser = null,
-        System.Numerics.BigInteger? chainId = null,
+        BigInteger? chainId = null,
         string jwt = null,
         string payload = null
     );
@@ -166,6 +167,14 @@ public interface IThirdwebWallet
     /// </summary>
     /// <returns>A list of <see cref="LinkedAccount"/> objects.</returns>
     Task<List<LinkedAccount>> GetLinkedAccounts();
+
+    /// <summary>
+    /// Signs an EIP-7702 authorization to invoke contract functions to an externally owned account.
+    /// </summary>
+    /// <param name="chainId">The chain ID of the contract.</param>
+    /// <param name="contractAddress">The address of the contract.</param>
+    /// <returns>The signed authorization as an <see cref="EIP7702Authorization"/> that can be used with <see cref="ThirdwebTransactionInput.AuthorizationList"/>.</returns>
+    Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress);
 }
 
 /// <summary>

--- a/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
@@ -173,8 +173,9 @@ public interface IThirdwebWallet
     /// </summary>
     /// <param name="chainId">The chain ID of the contract.</param>
     /// <param name="contractAddress">The address of the contract.</param>
+    /// <param name="willSelfExecute">Set to true if the wallet will also be the executor of the transaction, otherwise false.</param>
     /// <returns>The signed authorization as an <see cref="EIP7702Authorization"/> that can be used with <see cref="ThirdwebTransactionInput.AuthorizationList"/>.</returns>
-    Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress);
+    Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress, bool willSelfExecute);
 }
 
 /// <summary>

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
@@ -931,5 +931,10 @@ public partial class EcosystemWallet : IThirdwebWallet
         return Task.FromResult(address);
     }
 
+    public Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress)
+    {
+        throw new NotImplementedException();
+    }
+
     #endregion
 }

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
@@ -931,7 +931,7 @@ public partial class EcosystemWallet : IThirdwebWallet
         return Task.FromResult(address);
     }
 
-    public Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress)
+    public Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress, bool willSelfExecute)
     {
         throw new NotImplementedException();
     }

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -4,6 +4,7 @@ using Nethereum.ABI.EIP712;
 using Nethereum.Hex.HexConvertors.Extensions;
 using Nethereum.Hex.HexTypes;
 using Nethereum.Model;
+using Nethereum.RLP;
 using Nethereum.Signer;
 using Nethereum.Signer.EIP712;
 
@@ -383,6 +384,17 @@ public class PrivateKeyWallet : IThirdwebWallet
     public Task<List<LinkedAccount>> UnlinkAccount(LinkedAccount accountToUnlink)
     {
         throw new InvalidOperationException("UnlinkAccount is not supported for private key wallets.");
+    }
+
+    public async Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress)
+    {
+        var nonce = await this.GetTransactionCount(chainId);
+        var authorizationHash = Utils.HashMessage(
+            Utils.HexConcat("0x05", RLP.EncodeList(new HexBigInteger(chainId).HexValue.HexToBytes(), contractAddress.HexToBytes(), new HexBigInteger(nonce).HexValue.HexToBytes()).BytesToHex()[2..])
+        );
+        var authorizationSignature = await this.PersonalSign(authorizationHash);
+        var ecdsa = EthECDSASignatureFactory.ExtractECDSASignature(authorizationSignature);
+        return new EIP7702Authorization(chainId, contractAddress, nonce, ecdsa.V, ecdsa.R, ecdsa.S);
     }
 
     #endregion

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -2,7 +2,6 @@ using System.Numerics;
 using System.Text;
 using Nethereum.ABI.EIP712;
 using Nethereum.Hex.HexConvertors.Extensions;
-using Nethereum.Hex.HexTypes;
 using Nethereum.RLP;
 using Nethereum.Signer;
 using Nethereum.Signer.EIP712;
@@ -351,9 +350,9 @@ public class PrivateKeyWallet : IThirdwebWallet
                         RLP.EncodeElement(authorizationList.ChainId.HexToBigInt().ToBytesForRLPEncoding()),
                         RLP.EncodeElement(authorizationList.Address.HexToBytes()),
                         RLP.EncodeElement(authorizationList.Nonce.HexToBigInt().ToBytesForRLPEncoding()),
-                        RLP.EncodeElement(authorizationList.YParity.HexToBytes()),
-                        RLP.EncodeElement(authorizationList.R.HexToBytes()),
-                        RLP.EncodeElement(authorizationList.S.HexToBytes())
+                        RLP.EncodeElement(authorizationList.YParity.HexToBytes()[0] == 0 ? Array.Empty<byte>() : authorizationList.YParity.HexToBytes()),
+                        RLP.EncodeElement(authorizationList.R.HexToBytes().TrimZeroes()),
+                        RLP.EncodeElement(authorizationList.S.HexToBytes().TrimZeroes())
                     };
                     encodedAuthorizationList.Add(RLP.EncodeList(encodedItem.ToArray()));
                 }
@@ -402,7 +401,11 @@ public class PrivateKeyWallet : IThirdwebWallet
             Array.Copy(encodedBytes, 0, returnBytes, 1, encodedBytes.Length);
             returnBytes[0] = transaction.AuthorizationList != null ? (byte)0x04 : (byte)0x02;
 
+            // (var tx, var sig) = Utils.DecodeTransaction(returnBytes);
+
             signedTransaction = returnBytes.ToHex();
+
+            // (var tx, var sig) = Utils.DecodeTransaction("0x" + signedTransaction);
         }
 
         return Task.FromResult("0x" + signedTransaction);
@@ -461,12 +464,7 @@ public class PrivateKeyWallet : IThirdwebWallet
         {
             nonce++;
         }
-        var encodedData = new List<byte[]>
-        {
-            RLP.EncodeElement(new HexBigInteger(chainId).Value.ToBytesForRLPEncoding()),
-            RLP.EncodeElement(contractAddress.HexToBytes()),
-            RLP.EncodeElement(new HexBigInteger(nonce).Value.ToBytesForRLPEncoding())
-        };
+        var encodedData = new List<byte[]> { RLP.EncodeElement(chainId.ToBytesForRLPEncoding()), RLP.EncodeElement(contractAddress.HexToBytes()), RLP.EncodeElement(nonce.ToBytesForRLPEncoding()) };
         var encodedBytes = RLP.EncodeList(encodedData.ToArray());
         var returnElements = new byte[encodedBytes.Length + 1];
         Array.Copy(encodedBytes.ToArray(), 0, returnElements, 1, encodedBytes.Length);

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -346,9 +346,9 @@ public class PrivateKeyWallet : IThirdwebWallet
                 {
                     var encodedItem = new List<byte[]>()
                     {
-                        RLP.EncodeElement(authorizationList.ChainId.HexToBigInt().ToByteArrayForRLPEncoding()),
+                        RLP.EncodeElement(authorizationList.ChainId.HexToNumber().ToByteArrayForRLPEncoding()),
                         RLP.EncodeElement(authorizationList.Address.HexToBytes()),
-                        RLP.EncodeElement(authorizationList.Nonce.HexToBigInt().ToByteArrayForRLPEncoding()),
+                        RLP.EncodeElement(authorizationList.Nonce.HexToNumber().ToByteArrayForRLPEncoding()),
                         RLP.EncodeElement(authorizationList.YParity == "0x00" ? Array.Empty<byte>() : authorizationList.YParity.HexToBytes()),
                         RLP.EncodeElement(authorizationList.R.HexToBytes().TrimZeroes()),
                         RLP.EncodeElement(authorizationList.S.HexToBytes().TrimZeroes())
@@ -393,6 +393,7 @@ public class PrivateKeyWallet : IThirdwebWallet
             // (var tx, var sig) = Utils.DecodeTransaction(returnBytes);
 
             signedTransaction = returnBytes.ToHex();
+            Console.WriteLine(signedTransaction);
 
             // (var tx, var sig) = Utils.DecodeTransaction("0x" + signedTransaction);
         }

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -307,7 +307,6 @@ public class PrivateKeyWallet : IThirdwebWallet
 
         if (transaction.GasPrice != null)
         {
-            var gasPrice = transaction.GasPrice;
             var legacySigner = new LegacyTransactionSigner();
             signedTransaction = legacySigner.SignTransaction(
                 this.EcKey.GetPrivateKey(),
@@ -315,7 +314,7 @@ public class PrivateKeyWallet : IThirdwebWallet
                 transaction.To,
                 transaction.Value.Value,
                 transaction.Nonce.Value,
-                gasPrice.Value,
+                transaction.GasPrice.Value,
                 transaction.Gas.Value,
                 transaction.Data
             );

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -3,7 +3,6 @@ using System.Text;
 using Nethereum.ABI.EIP712;
 using Nethereum.Hex.HexConvertors.Extensions;
 using Nethereum.Hex.HexTypes;
-using Nethereum.Model;
 using Nethereum.RLP;
 using Nethereum.Signer;
 using Nethereum.Signer.EIP712;
@@ -300,10 +299,10 @@ public class PrivateKeyWallet : IThirdwebWallet
             throw new ArgumentNullException(nameof(transaction));
         }
 
-        var nonce = transaction.Nonce ?? throw new ArgumentNullException(nameof(transaction), "Transaction nonce has not been set");
-
-        var gasLimit = transaction.Gas;
-        var value = transaction.Value ?? new HexBigInteger(0);
+        if (transaction.Nonce == null)
+        {
+            throw new ArgumentNullException(nameof(transaction), "Transaction nonce has not been set");
+        }
 
         string signedTransaction;
 
@@ -315,10 +314,10 @@ public class PrivateKeyWallet : IThirdwebWallet
                 this.EcKey.GetPrivateKey(),
                 transaction.ChainId.Value,
                 transaction.To,
-                value.Value,
-                nonce,
+                transaction.Value.Value,
+                transaction.Nonce.Value,
                 gasPrice.Value,
-                gasLimit.Value,
+                transaction.Gas.Value,
                 transaction.Data
             );
         }
@@ -328,13 +327,82 @@ public class PrivateKeyWallet : IThirdwebWallet
             {
                 throw new InvalidOperationException("Transaction MaxPriorityFeePerGas and MaxFeePerGas must be set for EIP-1559 transactions");
             }
-            var maxPriorityFeePerGas = transaction.MaxPriorityFeePerGas.Value;
-            var maxFeePerGas = transaction.MaxFeePerGas.Value;
-            var transaction1559 = new Transaction1559(transaction.ChainId.Value, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, transaction.To, value, transaction.Data, null);
 
-            var signer = new Transaction1559Signer();
-            _ = signer.SignTransaction(this.EcKey, transaction1559);
-            signedTransaction = transaction1559.GetRLPEncoded().ToHex();
+            var encodedData = new List<byte[]>
+            {
+                RLP.EncodeElement(transaction.ChainId.Value.ToBytesForRLPEncoding()),
+                RLP.EncodeElement(transaction.Nonce.Value.ToBytesForRLPEncoding()),
+                RLP.EncodeElement(transaction.MaxPriorityFeePerGas.Value.ToBytesForRLPEncoding()),
+                RLP.EncodeElement(transaction.MaxFeePerGas.Value.ToBytesForRLPEncoding()),
+                RLP.EncodeElement(transaction.Gas.Value.ToBytesForRLPEncoding()),
+                RLP.EncodeElement(transaction.To.HexToBytes()),
+                RLP.EncodeElement(transaction.Value.Value.ToBytesForRLPEncoding()),
+                RLP.EncodeElement(transaction.Data.HexToBytes()),
+                new byte[] { 0xc0 }, // AccessList, empty so short list bytes
+            };
+
+            if (transaction.AuthorizationList != null)
+            {
+                var encodedAuthorizationList = new List<byte[]>();
+                foreach (var authorizationList in transaction.AuthorizationList)
+                {
+                    var encodedItem = new List<byte[]>()
+                    {
+                        RLP.EncodeElement(authorizationList.ChainId.HexToBytes()),
+                        RLP.EncodeElement(authorizationList.Address.HexToBytes()),
+                        RLP.EncodeElement(authorizationList.Nonce.HexToBytes()),
+                        RLP.EncodeElement(authorizationList.YParity.HexToBytes()),
+                        RLP.EncodeElement(authorizationList.R.HexToBytes().TrimZeroes()),
+                        RLP.EncodeElement(authorizationList.S.HexToBytes().TrimZeroes())
+                    };
+                    encodedAuthorizationList.Add(RLP.EncodeList(encodedItem.ToArray()));
+                }
+                encodedData.Add(RLP.EncodeList(encodedAuthorizationList.ToArray()));
+            }
+
+            var encodedBytes = RLP.EncodeList(encodedData.ToArray());
+            var returnBytes = new byte[encodedBytes.Length + 1];
+            Array.Copy(encodedBytes, 0, returnBytes, 1, encodedBytes.Length);
+            returnBytes[0] = transaction.AuthorizationList != null ? (byte)0x04 : (byte)0x02;
+
+            var rawHash = Utils.HashMessage(returnBytes);
+            var rawSignature = this.EcKey.SignAndCalculateYParityV(rawHash);
+
+            byte[] v;
+            byte[] r;
+            byte[] s;
+
+            if (rawSignature != null && rawSignature.V != null)
+            {
+                if (rawSignature.V.Length == 0 || rawSignature.V[0] == 0)
+                {
+                    v = Array.Empty<byte>();
+                }
+                else
+                {
+                    v = rawSignature.V;
+                }
+                v = RLP.EncodeElement(v);
+                r = RLP.EncodeElement(rawSignature.R.TrimZeroes());
+                s = RLP.EncodeElement(rawSignature.S.TrimZeroes());
+            }
+            else
+            {
+                v = RLP.EncodeElement(Array.Empty<byte>());
+                r = RLP.EncodeElement(Array.Empty<byte>());
+                s = RLP.EncodeElement(Array.Empty<byte>());
+            }
+
+            encodedData.Add(v);
+            encodedData.Add(r);
+            encodedData.Add(s);
+
+            encodedBytes = RLP.EncodeList(encodedData.ToArray());
+            returnBytes = new byte[encodedBytes.Length + 1];
+            Array.Copy(encodedBytes, 0, returnBytes, 1, encodedBytes.Length);
+            returnBytes[0] = transaction.AuthorizationList != null ? (byte)0x04 : (byte)0x02;
+
+            signedTransaction = returnBytes.ToHex();
         }
 
         return Task.FromResult("0x" + signedTransaction);
@@ -386,15 +454,26 @@ public class PrivateKeyWallet : IThirdwebWallet
         throw new InvalidOperationException("UnlinkAccount is not supported for private key wallets.");
     }
 
-    public async Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress)
+    public async Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress, bool willSelfExecute)
     {
         var nonce = await this.GetTransactionCount(chainId);
-        var authorizationHash = Utils.HashMessage(
-            Utils.HexConcat("0x05", RLP.EncodeList(new HexBigInteger(chainId).HexValue.HexToBytes(), contractAddress.HexToBytes(), new HexBigInteger(nonce).HexValue.HexToBytes()).BytesToHex()[2..])
-        );
-        var authorizationSignature = await this.PersonalSign(authorizationHash);
-        var ecdsa = EthECDSASignatureFactory.ExtractECDSASignature(authorizationSignature);
-        return new EIP7702Authorization(chainId, contractAddress, nonce, ecdsa.V, ecdsa.R, ecdsa.S);
+        if (willSelfExecute)
+        {
+            nonce++;
+        }
+        var encodedData = new List<byte[]>
+        {
+            RLP.EncodeElement(new HexBigInteger(chainId).Value.ToBytesForRLPEncoding()),
+            RLP.EncodeElement(contractAddress.HexToBytes()),
+            RLP.EncodeElement(new HexBigInteger(nonce).Value.ToBytesForRLPEncoding())
+        };
+        var encodedBytes = RLP.EncodeList(encodedData.ToArray());
+        var returnElements = new byte[encodedBytes.Length + 1];
+        Array.Copy(encodedBytes.ToArray(), 0, returnElements, 1, encodedBytes.Length);
+        returnElements[0] = 0x05;
+        var authorizationHash = Utils.HashMessage(returnElements);
+        var authorizationSignature = this.EcKey.SignAndCalculateYParityV(authorizationHash);
+        return new EIP7702Authorization(chainId, contractAddress, nonce, authorizationSignature.V, authorizationSignature.R, authorizationSignature.S);
     }
 
     #endregion

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -348,12 +348,12 @@ public class PrivateKeyWallet : IThirdwebWallet
                 {
                     var encodedItem = new List<byte[]>()
                     {
-                        RLP.EncodeElement(authorizationList.ChainId.HexToBytes()),
+                        RLP.EncodeElement(authorizationList.ChainId.HexToBigInt().ToBytesForRLPEncoding()),
                         RLP.EncodeElement(authorizationList.Address.HexToBytes()),
-                        RLP.EncodeElement(authorizationList.Nonce.HexToBytes()),
+                        RLP.EncodeElement(authorizationList.Nonce.HexToBigInt().ToBytesForRLPEncoding()),
                         RLP.EncodeElement(authorizationList.YParity.HexToBytes()),
-                        RLP.EncodeElement(authorizationList.R.HexToBytes().TrimZeroes()),
-                        RLP.EncodeElement(authorizationList.S.HexToBytes().TrimZeroes())
+                        RLP.EncodeElement(authorizationList.R.HexToBytes()),
+                        RLP.EncodeElement(authorizationList.S.HexToBytes())
                     };
                     encodedAuthorizationList.Add(RLP.EncodeList(encodedItem.ToArray()));
                 }

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -329,14 +329,14 @@ public class PrivateKeyWallet : IThirdwebWallet
 
             var encodedData = new List<byte[]>
             {
-                RLP.EncodeElement(transaction.ChainId.Value.ToBytesForRLPEncoding()),
-                RLP.EncodeElement(transaction.Nonce.Value.ToBytesForRLPEncoding()),
-                RLP.EncodeElement(transaction.MaxPriorityFeePerGas.Value.ToBytesForRLPEncoding()),
-                RLP.EncodeElement(transaction.MaxFeePerGas.Value.ToBytesForRLPEncoding()),
-                RLP.EncodeElement(transaction.Gas.Value.ToBytesForRLPEncoding()),
+                RLP.EncodeElement(transaction.ChainId.Value.ToByteArrayForRLPEncoding()),
+                RLP.EncodeElement(transaction.Nonce.Value.ToByteArrayForRLPEncoding()),
+                RLP.EncodeElement(transaction.MaxPriorityFeePerGas.Value.ToByteArrayForRLPEncoding()),
+                RLP.EncodeElement(transaction.MaxFeePerGas.Value.ToByteArrayForRLPEncoding()),
+                RLP.EncodeElement(transaction.Gas.Value.ToByteArrayForRLPEncoding()),
                 RLP.EncodeElement(transaction.To.HexToBytes()),
-                RLP.EncodeElement(transaction.Value.Value.ToBytesForRLPEncoding()),
-                RLP.EncodeElement(transaction.Data.HexToBytes()),
+                RLP.EncodeElement(transaction.Value.Value.ToByteArrayForRLPEncoding()),
+                RLP.EncodeElement(transaction.Data == null ? Array.Empty<byte>() : transaction.Data.HexToBytes()),
                 new byte[] { 0xc0 }, // AccessList, empty so short list bytes
             };
 
@@ -347,10 +347,10 @@ public class PrivateKeyWallet : IThirdwebWallet
                 {
                     var encodedItem = new List<byte[]>()
                     {
-                        RLP.EncodeElement(authorizationList.ChainId.HexToBigInt().ToBytesForRLPEncoding()),
+                        RLP.EncodeElement(authorizationList.ChainId.HexToBigInt().ToByteArrayForRLPEncoding()),
                         RLP.EncodeElement(authorizationList.Address.HexToBytes()),
-                        RLP.EncodeElement(authorizationList.Nonce.HexToBigInt().ToBytesForRLPEncoding()),
-                        RLP.EncodeElement(authorizationList.YParity.HexToBytes()[0] == 0 ? Array.Empty<byte>() : authorizationList.YParity.HexToBytes()),
+                        RLP.EncodeElement(authorizationList.Nonce.HexToBigInt().ToByteArrayForRLPEncoding()),
+                        RLP.EncodeElement(authorizationList.YParity == "0x00" ? Array.Empty<byte>() : authorizationList.YParity.HexToBytes()),
                         RLP.EncodeElement(authorizationList.R.HexToBytes().TrimZeroes()),
                         RLP.EncodeElement(authorizationList.S.HexToBytes().TrimZeroes())
                     };
@@ -370,27 +370,17 @@ public class PrivateKeyWallet : IThirdwebWallet
             byte[] v;
             byte[] r;
             byte[] s;
-
-            if (rawSignature != null && rawSignature.V != null)
+            if (rawSignature.V.Length == 0 || rawSignature.V[0] == 0)
             {
-                if (rawSignature.V.Length == 0 || rawSignature.V[0] == 0)
-                {
-                    v = Array.Empty<byte>();
-                }
-                else
-                {
-                    v = rawSignature.V;
-                }
-                v = RLP.EncodeElement(v);
-                r = RLP.EncodeElement(rawSignature.R.TrimZeroes());
-                s = RLP.EncodeElement(rawSignature.S.TrimZeroes());
+                v = Array.Empty<byte>();
             }
             else
             {
-                v = RLP.EncodeElement(Array.Empty<byte>());
-                r = RLP.EncodeElement(Array.Empty<byte>());
-                s = RLP.EncodeElement(Array.Empty<byte>());
+                v = rawSignature.V;
             }
+            v = RLP.EncodeElement(v);
+            r = RLP.EncodeElement(rawSignature.R.TrimZeroes());
+            s = RLP.EncodeElement(rawSignature.S.TrimZeroes());
 
             encodedData.Add(v);
             encodedData.Add(r);
@@ -464,7 +454,12 @@ public class PrivateKeyWallet : IThirdwebWallet
         {
             nonce++;
         }
-        var encodedData = new List<byte[]> { RLP.EncodeElement(chainId.ToBytesForRLPEncoding()), RLP.EncodeElement(contractAddress.HexToBytes()), RLP.EncodeElement(nonce.ToBytesForRLPEncoding()) };
+        var encodedData = new List<byte[]>
+        {
+            RLP.EncodeElement(chainId.ToByteArrayForRLPEncoding()),
+            RLP.EncodeElement(contractAddress.HexToBytes()),
+            RLP.EncodeElement(nonce.ToByteArrayForRLPEncoding())
+        };
         var encodedBytes = RLP.EncodeList(encodedData.ToArray());
         var returnElements = new byte[encodedBytes.Length + 1];
         Array.Copy(encodedBytes.ToArray(), 0, returnElements, 1, encodedBytes.Length);

--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -1225,5 +1225,10 @@ public class SmartWallet : IThirdwebWallet
         }
     }
 
+    public Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress)
+    {
+        return this._personalAccount.SignAuthorization(chainId, contractAddress);
+    }
+
     #endregion
 }

--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -1225,9 +1225,9 @@ public class SmartWallet : IThirdwebWallet
         }
     }
 
-    public Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress)
+    public Task<EIP7702Authorization> SignAuthorization(BigInteger chainId, string contractAddress, bool willSelfExecute)
     {
-        return this._personalAccount.SignAuthorization(chainId, contractAddress);
+        return this._personalAccount.SignAuthorization(chainId, contractAddress, willSelfExecute);
     }
 
     #endregion


### PR DESCRIPTION
Implements [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) as part of `ThirdwebTransactionInput` and allows wallets to `IThirdwebWallet.SignAuthorization` to generate it. Allows setting code to EOAs. Also added utilities to decode 1559 transactions including authorizationList.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing EIP-7702 authorization functionality in the `Thirdweb` wallet system, enhancing transaction capabilities, and adding tests for new features.

### Detailed summary
- Added `run` target to the `Makefile`.
- Implemented `SignAuthorization` method in `EcosystemWallet` and `SmartWallet`.
- Created tests for reading contracts and signing transactions.
- Introduced `Call` class in `Program.Types.cs`.
- Added `SignAuthorization` method in `IThirdwebWallet` interface.
- Enhanced transaction encoding with authorization handling in `ThirdwebTransaction`.
- Updated `ThirdwebTransactionInput` to include `AuthorizationList`.
- Created `EIP7702Authorization` struct for authorization data.
- Added methods for decoding transactions and authorization lists in `Utils`.
- Implemented tests for signing transactions with authorization in `PrivateKeyWallet`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->