### PR TITLE
ERC721_TotalSupply Include Burned NFTs

### DIFF
--- a/Thirdweb/Thirdweb.Extensions/ThirdwebExtensions.cs
+++ b/Thirdweb/Thirdweb.Extensions/ThirdwebExtensions.cs
@@ -651,7 +651,19 @@ public static class ThirdwebExtensions
     /// <exception cref="ArgumentNullException">Thrown when the contract is null.</exception>
     public static async Task<BigInteger> ERC721_TotalSupply(this ThirdwebContract contract)
     {
-        return contract == null ? throw new ArgumentNullException(nameof(contract)) : await ThirdwebContract.Read<BigInteger>(contract, "totalSupply");
+        if (contract == null)
+        {
+            throw new ArgumentNullException(nameof(contract));
+        }
+
+        try
+        {
+            return await ThirdwebContract.Read<BigInteger>(contract, "nextTokenIdToMint");
+        }
+        catch
+        {
+            return await ThirdwebContract.Read<BigInteger>(contract, "totalSupply");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #109 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ERC721_TotalSupply` method in the `ThirdwebExtensions` class to improve error handling and change the logic for retrieving the total supply of tokens.

### Detailed summary
- Changed the null check for `contract` to an `if` statement with a throw.
- Added a `try-catch` block to attempt reading `nextTokenIdToMint`.
- In case of an exception, it falls back to reading `totalSupply`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->