### PR TITLE
upload-artifact v4 upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: dotnet nuget push "./Thirdweb/bin/Release/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: |


### PR DESCRIPTION
Closes TOOL-2986

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `actions/upload-artifact` GitHub Action used in the `.github/workflows/release.yml` file from `v3` to `v4`.

### Detailed summary
- Updated `actions/upload-artifact` from `v3` to `v4` in the workflow configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->