### PR TITLE
Allow overriding Session ID for Guest mode

### DIFF
--- a/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/IThirdwebWallet.cs
@@ -143,6 +143,8 @@ public interface IThirdwebWallet
     /// <param name="chainId">The chain ID if linking an external wallet (SIWE).</param>
     /// <param name="jwt">The JWT token if linking custom JWT auth.</param>
     /// <param name="payload">The login payload if linking custom AuthEndpoint auth.</param>
+    /// <param name="defaultSessionIdOverride">The default session ID override if linking Guest auth.</param>
+    /// <param name="forceWalletIds">The wallet IDs to force display if linking using SiweExternal auth.</param>
     /// <returns>A list of <see cref="LinkedAccount"/> objects.</returns>
     public Task<List<LinkedAccount>> LinkAccount(
         IThirdwebWallet walletToLink,
@@ -153,7 +155,9 @@ public interface IThirdwebWallet
         IThirdwebBrowser browser = null,
         BigInteger? chainId = null,
         string jwt = null,
-        string payload = null
+        string payload = null,
+        string defaultSessionIdOverride = null,
+        List<string> forceWalletIds = null
     );
 
     /// <summary>

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
@@ -427,7 +427,9 @@ public partial class EcosystemWallet : IThirdwebWallet
         IThirdwebBrowser browser = null,
         BigInteger? chainId = null,
         string jwt = null,
-        string payload = null
+        string payload = null,
+        string defaultSessionIdOverride = null,
+        List<string> forceWalletIds = null
     )
     {
         if (!await this.IsConnected().ConfigureAwait(false))
@@ -496,11 +498,10 @@ public partial class EcosystemWallet : IThirdwebWallet
                 serverRes = await ecosystemWallet.PreAuth_AuthEndpoint(payload).ConfigureAwait(false);
                 break;
             case "Guest":
-                serverRes = await ecosystemWallet.PreAuth_Guest().ConfigureAwait(false);
+                serverRes = await ecosystemWallet.PreAuth_Guest(defaultSessionIdOverride).ConfigureAwait(false);
                 break;
             case "SiweExternal":
-                // TODO: Allow enforcing wallet ids in linking flow?
-                serverRes = await ecosystemWallet.PreAuth_SiweExternal(isMobile ?? false, browserOpenAction, null, mobileRedirectScheme, browser).ConfigureAwait(false);
+                serverRes = await ecosystemWallet.PreAuth_SiweExternal(isMobile ?? false, browserOpenAction, forceWalletIds, mobileRedirectScheme, browser).ConfigureAwait(false);
                 break;
             case "Google":
             case "Apple":
@@ -827,7 +828,7 @@ public partial class EcosystemWallet : IThirdwebWallet
 
     #region Guest
 
-    private async Task<Server.VerifyResult> PreAuth_Guest()
+    private async Task<Server.VerifyResult> PreAuth_Guest(string defaultSessionIdOverride = null)
     {
         var sessionData = this.EmbeddedWallet.GetSessionData();
         string sessionId;
@@ -837,15 +838,15 @@ public partial class EcosystemWallet : IThirdwebWallet
         }
         else
         {
-            sessionId = Guid.NewGuid().ToString();
+            sessionId = defaultSessionIdOverride ?? Guid.NewGuid().ToString();
         }
         var serverRes = await this.EmbeddedWallet.SignInWithGuestAsync(sessionId).ConfigureAwait(false);
         return serverRes;
     }
 
-    public async Task<string> LoginWithGuest()
+    public async Task<string> LoginWithGuest(string defaultSessionIdOverride = null)
     {
-        var serverRes = await this.PreAuth_Guest().ConfigureAwait(false);
+        var serverRes = await this.PreAuth_Guest(defaultSessionIdOverride).ConfigureAwait(false);
         return await this.PostAuth(serverRes).ConfigureAwait(false);
     }
 

--- a/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/PrivateKeyWallet/PrivateKeyWallet.cs
@@ -431,7 +431,9 @@ public class PrivateKeyWallet : IThirdwebWallet
         IThirdwebBrowser browser = null,
         BigInteger? chainId = null,
         string jwt = null,
-        string payload = null
+        string payload = null,
+        string defaultSessionIdOverride = null,
+        List<string> forceWalletIds = null
     )
     {
         throw new InvalidOperationException("LinkAccount is not supported for private key wallets.");

--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -1158,7 +1158,9 @@ public class SmartWallet : IThirdwebWallet
         IThirdwebBrowser browser = null,
         BigInteger? chainId = null,
         string jwt = null,
-        string payload = null
+        string payload = null,
+        string defaultSessionIdOverride = null,
+        List<string> forceWalletIds = null
     )
     {
         var personalWallet = await this.GetPersonalWallet().ConfigureAwait(false);
@@ -1180,7 +1182,9 @@ public class SmartWallet : IThirdwebWallet
         }
         else
         {
-            return await personalWallet.LinkAccount(walletToLink, otp, isMobile, browserOpenAction, mobileRedirectScheme, browser, chainId, jwt, payload).ConfigureAwait(false);
+            return await personalWallet
+                .LinkAccount(walletToLink, otp, isMobile, browserOpenAction, mobileRedirectScheme, browser, chainId, jwt, payload, defaultSessionIdOverride, forceWalletIds)
+                .ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
Closes TOOL-3133

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces additional parameters to the `LinkAccount` method across multiple wallet implementations, allowing for a more flexible linking process. It adds `defaultSessionIdOverride` and `forceWalletIds`, enhancing guest authentication and wallet linking functionalities.

### Detailed summary
- Added `defaultSessionIdOverride` and `forceWalletIds` parameters to `LinkAccount` method in:
  - `PrivateKeyWallet`
  - `SmartWallet`
  - `IThirdwebWallet`
  - `EcosystemWallet`
- Updated `PreAuth_Guest` to accept `defaultSessionIdOverride`.
- Modified calls to `PreAuth_Guest` and `PreAuth_SiweExternal` to use new parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->