### PR TITLE
Apply userop timeout based on client options

### DIFF
--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -798,11 +798,22 @@ public class SmartWallet : IThirdwebWallet
         // Wait for the transaction to be mined
 
         string txHash = null;
-        while (txHash == null)
+        using var ct = new CancellationTokenSource(this.Client.FetchTimeoutOptions.GetTimeout(TimeoutType.Other));
+        try
         {
-            var userOpReceipt = await BundlerClient.EthGetUserOperationReceipt(this.Client, this._bundlerUrl, requestId, userOpHash).ConfigureAwait(false);
-            txHash = userOpReceipt?.Receipt?.TransactionHash;
-            await ThirdwebTask.Delay(100).ConfigureAwait(false);
+            while (txHash == null)
+            {
+                ct.Token.ThrowIfCancellationRequested();
+
+                var userOpReceipt = await BundlerClient.EthGetUserOperationReceipt(this.Client, this._bundlerUrl, requestId, userOpHash).ConfigureAwait(false);
+
+                txHash = userOpReceipt?.Receipt?.TransactionHash;
+                await ThirdwebTask.Delay(100, ct.Token).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw new Exception($"User operation timed out with user op hash: {userOpHash}");
         }
 
         this.IsDeploying = false;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a cancellation mechanism for fetching the user operation receipt in the `SmartWallet` class, improving timeout handling and responsiveness.

### Detailed summary
- Replaced the initial `while` loop for fetching `txHash` with a `using` statement for `CancellationTokenSource`.
- Added a `try-catch` block to handle `OperationCanceledException`.
- Threw an exception with a message if the operation times out, instead of proceeding silently.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->