### PR TITLE
Allow login with tw auth token

### DIFF
--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
@@ -80,6 +80,7 @@ public partial class EcosystemWallet : IThirdwebWallet
     /// <param name="siweSigner">The SIWE signer wallet for SIWE authentication.</param>
     /// <param name="legacyEncryptionKey">The encryption key that is no longer required but was used in the past. Only pass this if you had used custom auth before this was deprecated.</param>
     /// <param name="walletSecret">The wallet secret for Backend authentication.</param>
+    /// <param name="twAuthTokenOverride">The auth token to use for the session. This will automatically connect using a raw thirdweb auth token.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the created in-app wallet.</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are not provided.</exception>
     public static async Task<EcosystemWallet> Create(
@@ -92,7 +93,8 @@ public partial class EcosystemWallet : IThirdwebWallet
         string storageDirectoryPath = null,
         IThirdwebWallet siweSigner = null,
         string legacyEncryptionKey = null,
-        string walletSecret = null
+        string walletSecret = null,
+        string twAuthTokenOverride = null
     )
     {
         if (client == null)
@@ -154,6 +156,10 @@ public partial class EcosystemWallet : IThirdwebWallet
 
         storageDirectoryPath ??= Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Thirdweb", "EcosystemWallet");
         var embeddedWallet = new EmbeddedWallet(client, storageDirectoryPath, ecosystemId, ecosystemPartnerId);
+        if (!string.IsNullOrWhiteSpace(twAuthTokenOverride))
+        {
+            CreateEnclaveSession(embeddedWallet, twAuthTokenOverride, email, phoneNumber, authproviderStr, null);
+        }
 
         try
         {

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.cs
@@ -37,6 +37,7 @@ public class InAppWallet : EcosystemWallet
     /// <param name="siweSigner">The SIWE signer wallet for SIWE authentication.</param>
     /// <param name="legacyEncryptionKey">The encryption key that is no longer required but was used in the past. Only pass this if you had used custom auth before this was deprecated.</param>
     /// <param name="walletSecret">The wallet secret for backend authentication.</param>
+    /// <param name="twAuthTokenOverride">The auth token to use for the session. This will automatically connect using a raw thirdweb auth token.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the created in-app wallet.</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are not provided.</exception>
     public static async Task<InAppWallet> Create(
@@ -47,11 +48,12 @@ public class InAppWallet : EcosystemWallet
         string storageDirectoryPath = null,
         IThirdwebWallet siweSigner = null,
         string legacyEncryptionKey = null,
-        string walletSecret = null
+        string walletSecret = null,
+        string twAuthTokenOverride = null
     )
     {
         storageDirectoryPath ??= Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Thirdweb", "InAppWallet");
-        var ecoWallet = await Create(client, null, null, email, phoneNumber, authProvider, storageDirectoryPath, siweSigner, legacyEncryptionKey, walletSecret);
+        var ecoWallet = await Create(client, null, null, email, phoneNumber, authProvider, storageDirectoryPath, siweSigner, legacyEncryptionKey, walletSecret, twAuthTokenOverride);
         return new InAppWallet(
             ecoWallet.Client,
             ecoWallet.EmbeddedWallet,


### PR DESCRIPTION
Useful in case you have a launcher and already have a session there, similar to generating an external login link for react from .net

Closes TOOL-3405

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new parameter, `twAuthTokenOverride`, to the `Create` methods in both `EcosystemWallet` and `InAppWallet`. This allows for session authentication using a raw thirdweb auth token.

### Detailed summary
- Added `twAuthTokenOverride` parameter to `Create` method in `EcosystemWallet.cs`.
- Implemented logic to use `twAuthTokenOverride` in session creation within `EcosystemWallet`.
- Added `twAuthTokenOverride` parameter to `Create` method in `InAppWallet.cs`.
- Updated call to `Create` in `InAppWallet` to include `twAuthTokenOverride`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->