### PR TITLE
Update to match new rotating secret key model

### DIFF
--- a/Thirdweb.Tests/Thirdweb.Client/Thirdweb.Client.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Client/Thirdweb.Client.Tests.cs
@@ -15,10 +15,9 @@ public class ClientTests : BaseTests
     public void SecretKeyInitialization()
     {
         var client = ThirdwebClient.Create(secretKey: this.SecretKey);
-        Assert.NotNull(client.ClientId);
         Assert.NotNull(client.SecretKey);
         Assert.Null(client.BundleId);
-        Assert.Equal(client.ClientId, Utils.ComputeClientIdFromSecretKey(client.SecretKey));
+        Assert.Null(client.ClientId);
         Assert.Equal(client.SecretKey, this.SecretKey);
     }
 
@@ -49,8 +48,7 @@ public class ClientTests : BaseTests
         Assert.NotNull(client.ClientId);
         Assert.NotNull(client.SecretKey);
         Assert.Null(client.BundleId);
-        Assert.NotEqual(client.ClientId, clientId);
-        Assert.Equal(client.ClientId, Utils.ComputeClientIdFromSecretKey(client.SecretKey));
+        Assert.Equal(client.ClientId, clientId);
         Assert.Equal(client.SecretKey, this.SecretKey);
     }
 
@@ -74,10 +72,10 @@ public class ClientTests : BaseTests
         var client = ThirdwebClient.Create(secretKey: this.SecretKey, bundleId: bundleId);
         Assert.NotNull(client.SecretKey);
         Assert.NotNull(client.BundleId);
-        Assert.NotNull(client.ClientId);
+        Assert.Null(client.ClientId);
         Assert.Equal(client.SecretKey, this.SecretKey);
         Assert.Equal(client.BundleId, bundleId);
-        Assert.Equal(client.ClientId, Utils.ComputeClientIdFromSecretKey(client.SecretKey));
+        Assert.Null(client.ClientId);
     }
 
     [Fact(Timeout = 120000)]

--- a/Thirdweb.Tests/Thirdweb.Utils/Thirdweb.Utils.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Utils/Thirdweb.Utils.Tests.cs
@@ -9,12 +9,6 @@ public class UtilsTests : BaseTests
         : base(output) { }
 
     [Fact(Timeout = 120000)]
-    public void ComputeClientIdFromSecretKey()
-    {
-        Assert.True(Utils.ComputeClientIdFromSecretKey(this.SecretKey).Length == 32);
-    }
-
-    [Fact(Timeout = 120000)]
     public void HexConcat()
     {
         var hexStrings = new string[] { "0x1234", "0x5678", "0x90AB" };

--- a/Thirdweb/Thirdweb.Client/ThirdwebClient.cs
+++ b/Thirdweb/Thirdweb.Client/ThirdwebClient.cs
@@ -44,10 +44,10 @@ public class ThirdwebClient
 
         if (!string.IsNullOrEmpty(secretKey))
         {
-            this.ClientId = Utils.ComputeClientIdFromSecretKey(secretKey);
             this.SecretKey = secretKey;
         }
-        else
+
+        if (!string.IsNullOrEmpty(clientId))
         {
             this.ClientId = clientId;
         }
@@ -61,9 +61,12 @@ public class ThirdwebClient
             { "x-sdk-name", sdkName ?? "Thirdweb.NET" },
             { "x-sdk-os", sdkOs ?? System.Runtime.InteropServices.RuntimeInformation.OSDescription },
             { "x-sdk-platform", sdkPlatform ?? "dotnet" },
-            { "x-sdk-version", sdkVersion ?? Constants.VERSION },
-            { "x-client-id", this.ClientId },
+            { "x-sdk-version", sdkVersion ?? Constants.VERSION }
         };
+        if (!string.IsNullOrEmpty(this.ClientId))
+        {
+            defaultHeaders.Add("x-client-id", this.ClientId);
+        }
         if (!string.IsNullOrEmpty(this.BundleId))
         {
             defaultHeaders.Add("x-bundle-id", this.BundleId);

--- a/Thirdweb/Thirdweb.Utils/Utils.cs
+++ b/Thirdweb/Thirdweb.Utils/Utils.cs
@@ -1,6 +1,5 @@
 ﻿using System.Globalization;
 using System.Numerics;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using ADRaffy.ENSNormalize;
@@ -30,23 +29,6 @@ public static partial class Utils
     private static readonly Dictionary<BigInteger, ThirdwebChainData> _chainDataCache = new();
     private static readonly Dictionary<string, string> _ensCache = new();
     private static readonly List<string[]> _errorSubstringsComposite = new() { new string[] { "account", "not found!" }, new[] { "wrong", "chainid" } };
-
-    /// <summary>
-    /// Computes the client ID from the given secret key.
-    /// </summary>
-    /// <param name="secretKey">The secret key.</param>
-    /// <returns>The computed client ID.</returns>
-    public static string ComputeClientIdFromSecretKey(string secretKey)
-    {
-#if NETSTANDARD
-        using var sha256 = SHA256.Create();
-        var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(secretKey));
-        return BitConverter.ToString(hash).Replace("-", "").ToLower()[..32];
-#else
-        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(secretKey));
-        return BitConverter.ToString(hash).Replace("-", "").ToLower()[..32];
-#endif
-    }
 
     // public static byte[] StringToSha256(string bytes)
     // {


### PR DESCRIPTION
Closes TOOL-3391

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the handling of `ClientId` and `SecretKey` in the `ThirdwebClient`, removing the computation of `ClientId` from `SecretKey` and adjusting related tests.

### Detailed summary
- Removed the `ComputeClientIdFromSecretKey` method from `Utils`.
- Modified `ThirdwebClient` to set `ClientId` based on provided `clientId` instead of computing it from `secretKey`.
- Updated tests to reflect changes in `ClientId` initialization and assertions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->