### PR TITLE
Rotating Secret Keys V2 Support

### DIFF
--- a/Thirdweb.Tests/Thirdweb.Client/Thirdweb.Client.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Client/Thirdweb.Client.Tests.cs
@@ -49,8 +49,8 @@ public class ClientTests : BaseTests
         Assert.NotNull(client.ClientId);
         Assert.NotNull(client.SecretKey);
         Assert.Null(client.BundleId);
-        Assert.NotEqual(client.ClientId, clientId);
-        Assert.Equal(client.ClientId, Utils.ComputeClientIdFromSecretKey(client.SecretKey));
+        Assert.Equal(client.ClientId, clientId);
+        Assert.NotEqual(client.ClientId, Utils.ComputeClientIdFromSecretKey(client.SecretKey));
         Assert.Equal(client.SecretKey, this.SecretKey);
     }
 

--- a/Thirdweb/Thirdweb.Client/ThirdwebClient.cs
+++ b/Thirdweb/Thirdweb.Client/ThirdwebClient.cs
@@ -42,16 +42,9 @@ public class ThirdwebClient
             throw new InvalidOperationException("ClientId or SecretKey must be provided");
         }
 
-        if (!string.IsNullOrEmpty(secretKey))
-        {
-            this.ClientId = Utils.ComputeClientIdFromSecretKey(secretKey);
-            this.SecretKey = secretKey;
-        }
-        else
-        {
-            this.ClientId = clientId;
-        }
-
+        // Respects provided clientId if any, otherwise computes it from secretKey
+        this.ClientId = !string.IsNullOrEmpty(clientId) ? clientId : (string.IsNullOrEmpty(secretKey) ? null : Utils.ComputeClientIdFromSecretKey(secretKey));
+        this.SecretKey = secretKey;
         this.BundleId = bundleId;
 
         this.FetchTimeoutOptions = fetchTimeoutOptions ?? new TimeoutOptions();


### PR DESCRIPTION
Closes TOOL-3391

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the logic for setting the `ClientId` in the `ThirdwebClient` class and modifying the related unit tests to reflect these changes.

### Detailed summary
- In `Thirdweb.Client.Tests.cs`, updated assertions to check `client.ClientId` against `clientId` directly and ensure it does not equal the computed value from `SecretKey`.
- In `ThirdwebClient.cs`, refactored the logic for setting `ClientId` to prioritize `clientId` if provided, otherwise compute from `SecretKey`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->