### PR TITLE
Chain metadata fetching util int -> BigInteger

### DIFF
--- a/Thirdweb/Thirdweb.Utils/Utils.Types.cs
+++ b/Thirdweb/Thirdweb.Utils/Utils.Types.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Numerics;
 
 namespace Thirdweb;
 
@@ -31,10 +32,10 @@ public class ThirdwebChainData
     public string ShortName { get; set; }
 
     [JsonProperty("chainId")]
-    public int ChainId { get; set; }
+    public BigInteger ChainId { get; set; }
 
     [JsonProperty("networkId")]
-    public int NetworkId { get; set; }
+    public BigInteger NetworkId { get; set; }
 
     [JsonProperty("slug")]
     public string Slug { get; set; }


### PR DESCRIPTION
Closes TOOL-3489

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ThirdwebChainData` class in the `Thirdweb.Utils` namespace to use `BigInteger` for `ChainId` and `NetworkId` properties instead of `int`, allowing for larger numerical values.

### Detailed summary
- Changed the type of `ChainId` from `int` to `BigInteger`.
- Changed the type of `NetworkId` from `int` to `BigInteger`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->