### PR TITLE
fix tests

### DIFF
--- a/Thirdweb.Tests/Thirdweb.RPC/Thirdweb.RPC.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.RPC/Thirdweb.RPC.Tests.cs
@@ -106,7 +106,8 @@ public class RpcTests : BaseTests
     {
         var client = ThirdwebClient.Create(clientId: "hi", fetchTimeoutOptions: new TimeoutOptions(rpc: 60000));
         var rpc = ThirdwebRPC.GetRpcInstance(client, 1);
-        _ = await Assert.ThrowsAsync<HttpRequestException>(async () => await rpc.SendRequestAsync<string>("eth_blockNumber"));
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(async () => await rpc.SendRequestAsync<string>("eth_blockNumber"));
+        Assert.Contains("Unauthorized", ex.Message);
     }
 
     [Fact(Timeout = 120000)]

--- a/Thirdweb.Tests/Thirdweb.Storage/Thirdweb.Storage.Tests.cs
+++ b/Thirdweb.Tests/Thirdweb.Storage/Thirdweb.Storage.Tests.cs
@@ -71,12 +71,12 @@ public class StorageTests : BaseTests
     }
 
     [Fact(Timeout = 120000)]
-    public async Task DownloadTest_400()
+    public async Task DownloadTest_404()
     {
         var client = ThirdwebClient.Create(secretKey: this.SecretKey);
-        var exception = await Assert.ThrowsAsync<Exception>(() => ThirdwebStorage.Download<string>(client, "https://0.rpc.thirdweb.com/"));
+        var exception = await Assert.ThrowsAsync<Exception>(() => ThirdwebStorage.Download<string>(client, "https://example.com/invalid-file"));
         Assert.Contains("Failed to download", exception.Message);
-        Assert.Contains("400", exception.Message);
+        Assert.Contains("404", exception.Message);
     }
 
     [Fact(Timeout = 120000)]

--- a/Thirdweb/Thirdweb.RPC/ThirdwebRPC.cs
+++ b/Thirdweb/Thirdweb.RPC/ThirdwebRPC.cs
@@ -181,8 +181,12 @@ public class ThirdwebRPC : IDisposable
                 throw new HttpRequestException(errorDetail);
             }
 
-            var responseJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            var responses = JsonConvert.DeserializeObject<List<RpcResponse<object>>>(responseJson);
+            var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (responseContent.Equals("Unauthorized", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new HttpRequestException("Unauthorized");
+            }
+            var responses = JsonConvert.DeserializeObject<List<RpcResponse<object>>>(responseContent);
 
             foreach (var rpcResponse in responses)
             {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling in the `Thirdweb.RPC` and `Thirdweb.Storage` components by refining exception messages and updating test cases to reflect accurate HTTP status codes.

### Detailed summary
- In `Thirdweb.RPC.Tests.cs`, changed the variable name from `ex` to `exception` and added an assertion to check if the exception message contains "Unauthorized".
- In `ThirdwebRPC.cs`, added a check for "Unauthorized" response and threw an `HttpRequestException` if matched.
- In `Thirdweb.Storage.Tests.cs`, updated the test method name from `DownloadTest_400` to `DownloadTest_404` and changed the URL to an invalid one, asserting for a "404" status instead of "400".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->