### PR TITLE
Throw if GetEcosystemDetails is called on an InAppWallet

### DIFF
--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
@@ -373,6 +373,7 @@ public partial class EcosystemWallet : IThirdwebWallet
     /// Returns Ecosystem metadata (set in thirdweb Dashboard)
     /// </summary>
     /// <returns>Instance of <see cref="EcosystemDetails"/> containing metadata</returns>
+    /// <exception cref="InvalidOperationException">Thrown when called on an InAppWallet</exception>
     public async Task<EcosystemDetails> GetEcosystemDetails()
     {
         if (this.GetType().Name.Contains("InAppWallet"))
@@ -391,6 +392,7 @@ public partial class EcosystemWallet : IThirdwebWallet
     /// </summary>
     /// <param name="redirectUrl">The URL of your thirdweb-powered website.</param>
     /// <returns>The URL to redirect the user to.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no connected session is found</exception>
     public string GenerateExternalLoginLink(string redirectUrl)
     {
         var authProvider = HttpUtility.UrlEncode(this.AuthProvider.ToLower());


### PR DESCRIPTION
Avoid the fetch call when creating a smart wallet with an InAppWallet as well
Fixes [TOOL-3726](https://linear.app/thirdweb/issue/TOOL-3726)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `EcosystemWallet` class by adding XML documentation comments for better code clarity and introduces error handling in the `GetEcosystemDetails` method, ensuring it cannot be called from an `InAppWallet`. It also adds a new method `GenerateExternalLoginLink`.

### Detailed summary
- Added XML documentation for `GetEcosystemDetails` method.
- Implemented error handling in `GetEcosystemDetails` to throw `InvalidOperationException` if called from an `InAppWallet`.
- Added XML documentation for `GenerateExternalLoginLink` method, describing its parameters and return value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->