### PR TITLE
Use invariant culture for AWS date formatting

### DIFF
--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet.Authentication/AWS.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EmbeddedWallet.Authentication/AWS.cs
@@ -132,8 +132,8 @@ internal class AWS
 
         var dateTimeNow = dateOverride ?? DateTime.UtcNow;
         var amzDateFormat = "yyyyMMddTHHmmssZ";
-        var amzDate = dateTimeNow.ToString(amzDateFormat);
-        var dateStamp = dateTimeNow.ToString("yyyyMMdd");
+        var amzDate = dateTimeNow.ToString(amzDateFormat, System.Globalization.CultureInfo.InvariantCulture);
+        var dateStamp = dateTimeNow.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture);
 
         var canonicalHeaders = $"host:{new Uri(endpoint).Host}\n" + $"x-amz-date:{amzDate}\n";
         var signedHeaders = "host;x-amz-date";
@@ -181,7 +181,7 @@ internal class AWS
                 if (idx > -1)
                 {
                     var parsedTimeString = responseContent.Substring(idx + 1, amzDate.Length);
-                    var serverTime = DateTime.ParseExact(parsedTimeString, amzDateFormat, System.Globalization.CultureInfo.InvariantCulture).ToUniversalTime();
+                    var serverTime = DateTime.ParseExact(parsedTimeString, amzDateFormat, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AssumeUniversal);
 
                     return await PostAwsRequestWithDateOverride(
                             credentials,


### PR DESCRIPTION
Updated date formatting and parsing in AWS authentication to explicitly use System.Globalization.CultureInfo.InvariantCulture and DateTimeStyles.AssumeUniversal. This ensures consistent behavior regardless of system locale.

Closes BLD-298

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the date formatting in the `AWS.cs` file by ensuring that date strings are consistently formatted using `System.Globalization.CultureInfo.InvariantCulture`.

### Detailed summary
- Updated `amzDate` and `dateStamp` to use `CultureInfo.InvariantCulture` for string formatting.
- Modified the `serverTime` parsing to include `DateTimeStyles.AssumeUniversal` for accurate time interpretation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved authentication failures caused by locale-specific date formatting.
  * Fixed intermittent “signature expired” errors by correctly interpreting server time as UTC during retries.

* **Reliability**
  * Standardized time handling to be culture-invariant, ensuring consistent request signing across regions and reducing false expiration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->