### PR TITLE
Add Epic as new AuthProvider in InAppWallet

### DIFF
--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs
@@ -135,6 +135,7 @@ public partial class EcosystemWallet : IThirdwebWallet
             Thirdweb.AuthProvider.Guest => "Guest",
             Thirdweb.AuthProvider.X => "X",
             Thirdweb.AuthProvider.TikTok => "TikTok",
+            Thirdweb.AuthProvider.Epic => "Epic",
             Thirdweb.AuthProvider.Coinbase => "Coinbase",
             Thirdweb.AuthProvider.Github => "Github",
             Thirdweb.AuthProvider.Twitch => "Twitch",
@@ -715,6 +716,7 @@ public partial class EcosystemWallet : IThirdwebWallet
             case "Line":
             case "X":
             case "TikTok":
+            case "Epic":
             case "Coinbase":
             case "Github":
             case "Twitch":

--- a/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.Types.cs
+++ b/Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.Types.cs
@@ -21,6 +21,7 @@ public enum AuthProvider
     Guest,
     X,
     TikTok,
+    Epic,
     Coinbase,
     Github,
     Twitch,


### PR DESCRIPTION
Introduces 'Epic' as a supported AuthProvider in the InAppWallet system, updating the enum and relevant switch statements to handle the new provider.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for a new authentication provider, `Epic`, to the `InAppWallet` system. It updates the relevant types and account linking logic to include this provider.

### Detailed summary
- Added `Epic` to `Thirdweb/Thirdweb.Wallets/InAppWallet/InAppWallet.Types.cs`.
- Updated `Thirdweb.AuthProvider` mappings in `Thirdweb/Thirdweb.Wallets/InAppWallet/EcosystemWallet/EcosystemWallet.cs`.
- Included `Epic` in the account linking switch case in the method `LinkAccount`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for Epic as a new authentication provider, allowing users to sign in and link accounts using their Epic credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->