### PR TITLE
Make CreateSessionKey parameters optional with defaults

### DIFF
--- a/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
+++ b/Thirdweb/Thirdweb.Wallets/SmartWallet/SmartWallet.cs
@@ -402,12 +402,12 @@ public class SmartWallet : IThirdwebWallet
     /// <param name="reqValidityEndTimestamp">The timestamp when the request validity ends. Make use of our Utils to get UNIX timestamps.</param>
     public async Task<ThirdwebTransactionReceipt> CreateSessionKey(
         string signerAddress,
-        List<string> approvedTargets,
-        string nativeTokenLimitPerTransactionInWei,
-        string permissionStartTimestamp,
-        string permissionEndTimestamp,
-        string reqValidityStartTimestamp,
-        string reqValidityEndTimestamp
+        List<string> approvedTargets = null,
+        string nativeTokenLimitPerTransactionInWei = null,
+        string permissionStartTimestamp = null,
+        string permissionEndTimestamp = null,
+        string reqValidityStartTimestamp = null,
+        string reqValidityEndTimestamp = null
     )
     {
         if (await Utils.IsZkSync(this.Client, this.ActiveChainId).ConfigureAwait(false))
@@ -419,12 +419,12 @@ public class SmartWallet : IThirdwebWallet
         {
             Signer = signerAddress,
             IsAdmin = 0,
-            ApprovedTargets = approvedTargets,
-            NativeTokenLimitPerTransaction = BigInteger.Parse(nativeTokenLimitPerTransactionInWei),
-            PermissionStartTimestamp = BigInteger.Parse(permissionStartTimestamp),
-            PermissionEndTimestamp = BigInteger.Parse(permissionEndTimestamp),
-            ReqValidityStartTimestamp = BigInteger.Parse(reqValidityStartTimestamp),
-            ReqValidityEndTimestamp = BigInteger.Parse(reqValidityEndTimestamp),
+            ApprovedTargets = approvedTargets ?? new List<string> { Constants.ADDRESS_ZERO },
+            NativeTokenLimitPerTransaction = BigInteger.Parse(nativeTokenLimitPerTransactionInWei ?? "0"),
+            PermissionStartTimestamp = BigInteger.Parse(permissionStartTimestamp ?? "0"),
+            PermissionEndTimestamp = BigInteger.Parse(permissionEndTimestamp ?? Utils.GetUnixTimeStampIn10Years().ToString()),
+            ReqValidityStartTimestamp = BigInteger.Parse(reqValidityStartTimestamp ?? "0"),
+            ReqValidityEndTimestamp = BigInteger.Parse(reqValidityEndTimestamp ?? Utils.GetUnixTimeStampIn10Years().ToString()),
             Uid = Guid.NewGuid().ToByteArray(),
         };
 


### PR DESCRIPTION
Updated the CreateSessionKey method to provide default values for its parameters, allowing them to be optional. This improves usability by enabling callers to omit parameters, which will then be set to sensible defaults within the method.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `CreateSessionKey` method in the `SmartWallet` class to allow optional parameters with default values, enhancing flexibility when creating session keys.

### Detailed summary
- Changed parameters in `CreateSessionKey` to have default values (set to `null`).
- Updated the assignment of `ApprovedTargets` to use a default list if `approvedTargets` is `null`.
- Adjusted parsing for other parameters to handle `null` values, providing default fallbacks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SmartWallet session key creation is now more flexible. The CreateSessionKey method's parameters are now optional with intelligent defaults: approved targets default to all addresses, transaction limits default to unlimited, permission start times default to immediate, and permission validity windows default to 10 years.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->